### PR TITLE
expanding the distortion and isObservable apis to provide obj and key for the value to be inspected

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ As described above, you can use distortions to avoid leaking non-observable obje
 import ObservableMembrane from 'observable-membrane';
 
 const membrane = new ObservableMembrane({
-    valueDistortion(value) {
+    valueDistortion(value, obj, key) {
         if (value instanceof Node) {
             throw new ReferenceError(`Invalid access to a non-observable Node`);
         }
@@ -142,6 +142,8 @@ const membrane = new ObservableMembrane({
         if (value === 1) {
             return 10;
         }
+        // additionally, you can use the second and third argument to narrow the
+        // distortion logic even more. Considering that obj[key] === value
         return value;
     },
 });
@@ -169,6 +171,27 @@ p.y.node;
 ```
 
 _Note: You could use a `WeakMap` to remap symbols to avoid leaking the original symbols and other non-observable objects through the distortion mechanism._
+
+_Note: By default, the distortion mechanism does nothing._
+
+#### Observables
+
+As described above, you can decide whether or not a value should be considered an observable objects, which means it must be wrapped by with a Proxy, e.g.:
+
+```js
+import ObservableMembrane from 'observable-membrane';
+
+const membrane = new ObservableMembrane({
+    valueIsObservable(value, obj, key) {
+        // any object is observable (wrapped) except for Node instances
+        return !(value instanceof Node) {
+        // additionally, you can use the second and third argument to narrow the
+        // logic even more, considering that obj[key] === value.
+    },
+});
+```
+
+_Note: By default, only POJOs (objects and arrays created from syntax) are considered observables._
 
 #### Unwrapping Proxies
 
@@ -210,7 +233,8 @@ Create a new membrane.
 * `config` [Object] [Optional] The membrane configuration
     * `valueObserved` [Function] [Optional] Callback invoked when an observed  property is accessed. This function receives as argument the original target and the property key.
     * `valueMutated` [Function] [Optional] Callback invoked when an observed property is mutated. This function receives as argument the original target and the property key.
-    * `valueDistortion` [Function] [Optional] Callback to apply distortion to the objects present in the object graph. This function receives as argument a newly added object in the object graph.
+    * `valueDistortion` [Function] [Optional] Callback to apply distortion to a value accessible from an object in the object graph. This function receives as arguments a value, an object and the property key from where the value was obtained.
+    * `valueIsObservable` [Function] [Optional] Callback to determine if a value accessible from an object in the object graph is observable or not. This function receives as arguments a value, an object and the property key from where the value was obtained.
 
 
 ### `ObservableMembrane.prototype.getProxy(object)`

--- a/src/read-only-handler.ts
+++ b/src/read-only-handler.ts
@@ -15,8 +15,8 @@ import {
     wrapDescriptor,
 } from './reactive-membrane';
 
-function wrapReadOnlyValue(membrane: ReactiveMembrane, value: any): any {
-    return membrane.valueIsObservable(value) ? membrane.getReadOnlyProxy(value) : value;
+function wrapReadOnlyValue(membrane: ReactiveMembrane, value: any, obj: any, key: PropertyKey): any {
+    return membrane.valueIsObservable(value, obj, key) ? membrane.getReadOnlyProxy(value, obj, key) : value;
 }
 
 export class ReadOnlyHandler {
@@ -35,7 +35,7 @@ export class ReadOnlyHandler {
         const value = originalTarget[key];
         const { valueObserved } = membrane;
         valueObserved(originalTarget, key);
-        return membrane.getReadOnlyProxy(value);
+        return membrane.getReadOnlyProxy(value, originalTarget, key);
     }
     set(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey, value: any): boolean {
         if (process.env.NODE_ENV !== 'production') {
@@ -90,7 +90,7 @@ export class ReadOnlyHandler {
         // Note: by accessing the descriptor, the key is marked as observed
         // but access to the value or getter (if available) cannot be observed,
         // just like regular methods, in which case we just do nothing.
-        desc = wrapDescriptor(membrane, desc, wrapReadOnlyValue);
+        desc = wrapDescriptor(membrane, desc, originalTarget, key, wrapReadOnlyValue);
         if (hasOwnProperty.call(desc, 'set')) {
             desc.set = undefined; // readOnly membrane does not allow setters
         }


### PR DESCRIPTION
Until now, the distortion mechanism and the isObservable mechanism will only expose the value to be analyzed, without providing explicit knowledge about how that value was obtained. This PR changes that, and now both APIs will be able to tell what object, and what key were used to obtain the value for the distortion or for the observable analysis.

This is supposed to help membrane authors to identify potential poisoning via readonly membranes, e.g.:

```js
{
    forEach(...) {
        ...
    },
    length: 1,
}
```

From the receiver point of view, this looks like an array, and calling `forEach` from it, will work as expected (imagina the the receiver is normalizing the provided value), and now the provider can observe the result of that normalization by defining the forEach method that calls the read forEach.

This can be prevented if you know the object and the key that is providing the function value in the first place, and compare them to the array prototype, and halt any poisoning attempt by throwing an error.