### PR TITLE
fix: Object.prototype and Array.prototype are not observable

### DIFF
--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -47,12 +47,19 @@ function createShadowTarget(value: any): ReactiveMembraneShadowTarget {
 }
 
 const ObjectDotPrototype = Object.prototype;
+const ArrayDotPrototype = Array.prototype;
 
 function defaultValueIsObservable(value: any): boolean {
     // intentionally checking for null and undefined
-    if (value == null) {
+    if (value === null || isUndefined(value)) {
         return false;
     }
+
+    // escape hatch for intrinsics, else these will be false positives under the checks below
+    if (value === ObjectDotPrototype || value === ArrayDotPrototype) {
+        return false;
+    }
+
     if (isArray(value)) {
         return true;
     }

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -679,4 +679,22 @@ describe('ReactiveHandler', () => {
             expect(observedTarget).toBe(todos);
         });
     });
+    describe('should never wrap intrinsic prototypes', () => {
+        let membraneWithDefaults;
+        beforeAll(() => {
+            membraneWithDefaults = new ReactiveMembrane();
+        });
+
+        it('accessing proto of object should return Object.prototype', () => {
+            const obj = {};
+            const wet = membraneWithDefaults.getProxy(obj);
+            expect(wet.__proto__).toBe(Object.prototype);
+        })
+
+        it('accessing proto of array should return Array.prototype', () => {
+            const arr = [];
+            const wet = membraneWithDefaults.getProxy(arr);
+            expect(wet.__proto__).toBe(Array.prototype);
+        })    
+    });
 });

--- a/test/reactive-membrane.spec.ts
+++ b/test/reactive-membrane.spec.ts
@@ -41,3 +41,22 @@ describe('constructor', () => {
         expect(wet.source).toBe("fooBar");
     });
 });
+
+describe('Does not wrap non-observables', () => {
+    let membrane;
+    beforeEach(() => {
+        membrane = new ReactiveMembrane();
+    });
+
+    it('should not wrap or distort Object.prototype', () => {
+        const ObjectDotPrototype = Object.prototype;
+        expect(membrane.getProxy(ObjectDotPrototype)).toBe(ObjectDotPrototype);
+        expect(membrane.getReadOnlyProxy(ObjectDotPrototype)).toBe(ObjectDotPrototype);
+    });
+
+    it('should not wrap or distort Array.prototype', () => {
+        const ArrayDotPrototye =  Array.prototype;
+        expect(membrane.getProxy(ArrayDotPrototye)).toBe(ArrayDotPrototye);
+        expect(membrane.getReadOnlyProxy(ArrayDotPrototye)).toBe(ArrayDotPrototye);
+    });
+});

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -372,4 +372,23 @@ describe('ReadOnlyHandler', () => {
             Object.setPrototypeOf(property.foo, {});
         }).toThrow();
     });
+
+    describe('should never wrap intrinsic prototypes', () => {
+        let membraneWithDefaults;
+        beforeAll(() => {
+            membraneWithDefaults = new ReactiveMembrane();
+        });
+
+        it('accessing proto of object should return Object.prototype', () => {
+            const obj = {};
+            const wet = membraneWithDefaults.getReadOnlyProxy(obj);
+            expect(wet.__proto__).toBe(Object.prototype);
+        })
+
+        it('accessing proto of array should return Array.prototype', () => {
+            const arr = [];
+            const wet = membraneWithDefaults.getReadOnlyProxy(arr);
+            expect(wet.__proto__).toBe(Array.prototype);
+        })    
+    });
 });


### PR DESCRIPTION
Object.prototype and Array.prototype were passing off as observables but they are not.

This change fixes that.