### PR TITLE
perf: Faster checks for non-observable types

### DIFF
--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -49,27 +49,22 @@ function createShadowTarget(value: any): ReactiveMembraneShadowTarget {
 const ObjectDotPrototype = Object.prototype;
 
 function defaultValueIsObservable(value: any): boolean {
-    // intentionally checking for null and undefined
-    if (value == null) {
+    // intentionally checking for null
+    if (value === null) {
         return false;
     }
 
-    switch (typeof value) {
-        // Quicker decisions for non-observable types. All possible values of typeof https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#Description
-        case 'boolean':
-        case 'number':
-        case 'string':
-        case 'symbol':
-        case 'function':
-            return false;
-        default:
-            if (isArray(value)) {
-                return true;
-            }
-
-            const proto = getPrototypeOf(value);
-            return (proto === ObjectDotPrototype || proto === null || getPrototypeOf(proto) === null);
+    // treat all non-object types, including undefined, as non-observable values
+    if (typeof value !== 'object') {
+        return false;
     }
+
+    if (isArray(value)) {
+        return true;
+    }
+
+    const proto = getPrototypeOf(value);
+    return (proto === ObjectDotPrototype || proto === null || getPrototypeOf(proto) === null);
 }
 
 const defaultValueObserved: ReactiveMembraneAccessCallback = (obj: any, key: PropertyKey) => {

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -53,12 +53,23 @@ function defaultValueIsObservable(value: any): boolean {
     if (value == null) {
         return false;
     }
-    if (isArray(value)) {
-        return true;
-    }
 
-    const proto = getPrototypeOf(value);
-    return (proto === ObjectDotPrototype || proto === null || getPrototypeOf(proto) === null);
+    switch (typeof value) {
+        // Quicker decisions for non-observable types. All possible values of typeof https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#Description
+        case 'boolean':
+        case 'number':
+        case 'string':
+        case 'symbol':
+        case 'function':
+            return false;
+        default:
+            if (isArray(value)) {
+                return true;
+            }
+
+            const proto = getPrototypeOf(value);
+            return (proto === ObjectDotPrototype || proto === null || getPrototypeOf(proto) === null);
+    }
 }
 
 const defaultValueObserved: ReactiveMembraneAccessCallback = (obj: any, key: PropertyKey) => {


### PR DESCRIPTION
The defaultValueIsObservable() can make quick decisions for leaf nodes in an object with a simpler typeof check instead of the expensive Array.isArray() + Object.getPrototypeOf()

Attached is the perf results for this specific change.

![screen shot 2018-12-17 at 3 04 36 pm](https://user-images.githubusercontent.com/931465/50121274-1d3edc00-020d-11e9-9fe8-c82fd673b6a8.png)

https://jsbench.me/iujpswz843/1

You will notice that when accessing a leaf node in an observable, the performance improved by 10 times. When accessing a nested observable, the additional typeof check is insignificant.