### PR TITLE
fix: Add global this value lookup to enable node support

### DIFF
--- a/src/reactive-dev-formatter.ts
+++ b/src/reactive-dev-formatter.ts
@@ -63,12 +63,14 @@ const formatter: DevToolFormatter = {
     }
 };
 
+// Inspired from paulmillr/es6-shim
+// https://github.com/paulmillr/es6-shim/blob/master/es6-shim.js#L176-L185
 function getGlobal(): any {
     // the only reliable means to get the global object is `Function('return this')()`
     // However, this causes CSP violations in Chrome apps.
     if (typeof self !== 'undefined') { return self; }
-    if (typeof window !== 'undefined') { return window; }
-    if (typeof global !== 'undefined') { return global; }
+    else if (typeof window !== 'undefined') { return window; }
+    else if (typeof global !== 'undefined') { return global; }
 
     // Gracefully degrade if not able to locate the global object
     return {};

--- a/src/reactive-dev-formatter.ts
+++ b/src/reactive-dev-formatter.ts
@@ -69,8 +69,8 @@ function getGlobal(): any {
     // the only reliable means to get the global object is `Function('return this')()`
     // However, this causes CSP violations in Chrome apps.
     if (typeof self !== 'undefined') { return self; }
-    else if (typeof window !== 'undefined') { return window; }
-    else if (typeof global !== 'undefined') { return global; }
+    if (typeof window !== 'undefined') { return window; }
+    if (typeof global !== 'undefined') { return global; }
 
     // Gracefully degrade if not able to locate the global object
     return {};

--- a/src/reactive-dev-formatter.ts
+++ b/src/reactive-dev-formatter.ts
@@ -9,7 +9,7 @@ import {
     getOwnPropertySymbols,
 } from './shared';
 
-// Define globalThis here since it's not current defined in by typescript.
+// Define globalThis since it's not current defined in by typescript.
 // https://github.com/tc39/proposal-global
 declare var globalThis: any;
 

--- a/src/reactive-dev-formatter.ts
+++ b/src/reactive-dev-formatter.ts
@@ -9,6 +9,10 @@ import {
     getOwnPropertySymbols,
 } from './shared';
 
+// Define globalThis here since it's not current defined in by typescript.
+// https://github.com/tc39/proposal-global
+declare var globalThis: any;
+
 interface DevToolFormatter {
     header: (object: any, config: any) => any;
     hasBody: (object: any, config: any) => boolean | null;
@@ -68,6 +72,7 @@ const formatter: DevToolFormatter = {
 function getGlobal(): any {
     // the only reliable means to get the global object is `Function('return this')()`
     // However, this causes CSP violations in Chrome apps.
+    if (typeof globalThis !== 'undefined') { return globalThis; }
     if (typeof self !== 'undefined') { return self; }
     if (typeof window !== 'undefined') { return window; }
     if (typeof global !== 'undefined') { return global; }


### PR DESCRIPTION
Add global object lookup to not only rely on the `window` object but also `global` (node) and `self` (web worker).

Fix #29 