### PR TITLE
feat: add capability to identify membrane proxies

### DIFF
--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -143,6 +143,7 @@ export abstract class BaseProxyHandler {
             // we produce a synthetic descriptor and install it on the shadow target
             desc = { value: undefined, writable: false, configurable: false, enumerable: false };
             ObjectDefineProperty(shadowTarget, tagPropertyKey, desc);
+            return desc;
         }
         if (desc.configurable === false) {
             // updating the descriptor to non-configurable on the shadow

--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -140,8 +140,9 @@ export abstract class BaseProxyHandler {
                 return undefined;
             }
             // if the key is the membrane tag key, and is not in the original target,
-            // we produce a synthetic descriptor
+            // we produce a synthetic descriptor and install it on the shadow target
             desc = { value: undefined, writable: false, configurable: false, enumerable: false };
+            ObjectDefineProperty(shadowTarget, tagPropertyKey, desc);
         }
         if (desc.configurable === false) {
             // updating the descriptor to non-configurable on the shadow

--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -1,4 +1,5 @@
 import {
+    ArrayConcat,
     getPrototypeOf,
     getOwnPropertyNames,
     getOwnPropertySymbols,
@@ -62,10 +63,7 @@ export abstract class BaseProxyHandler {
     }
     lockShadowTarget(shadowTarget: ReactiveMembraneShadowTarget): void {
         const { originalTarget } = this;
-        const targetKeys: PropertyKey[] = [];
-        // small perf optimization using push instead of concat to avoid creating an extra array
-        ArrayPush.apply(targetKeys, getOwnPropertyNames(originalTarget));
-        ArrayPush.apply(targetKeys, getOwnPropertySymbols(originalTarget));
+        const targetKeys: PropertyKey[] = ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
         targetKeys.forEach((key: PropertyKey) => {
             this.copyDescriptorIntoShadowTarget(shadowTarget, key);
         });

--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -1,5 +1,4 @@
 import {
-    ArrayConcat,
     getPrototypeOf,
     getOwnPropertyNames,
     getOwnPropertySymbols,
@@ -9,16 +8,13 @@ import {
     hasOwnProperty,
     ObjectDefineProperty,
     preventExtensions,
-    isArray,
     freeze,
+    ArrayPush,
+    ObjectCreate,
 } from './shared';
 import { ReactiveMembrane } from './reactive-membrane';
 
 export type ReactiveMembraneShadowTarget = object;
-
-export function createShadowTarget(value: any): ReactiveMembraneShadowTarget {
-    return isArray(value) ? [] : {};
-}
 
 export abstract class BaseProxyHandler {
     originalTarget: any;
@@ -66,10 +62,17 @@ export abstract class BaseProxyHandler {
     }
     lockShadowTarget(shadowTarget: ReactiveMembraneShadowTarget): void {
         const { originalTarget } = this;
-        const targetKeys = ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
+        const targetKeys: PropertyKey[] = [];
+        // small perf optimization using push instead of concat to avoid creating an extra array
+        ArrayPush.apply(targetKeys, getOwnPropertyNames(originalTarget));
+        ArrayPush.apply(targetKeys, getOwnPropertySymbols(originalTarget));
         targetKeys.forEach((key: PropertyKey) => {
             this.copyDescriptorIntoShadowTarget(shadowTarget, key);
         });
+        const { membrane: { tagPropertyKey } } = this;
+        if (!isUndefined(tagPropertyKey) && !hasOwnProperty.call(shadowTarget, tagPropertyKey)) {
+            ObjectDefineProperty(shadowTarget, tagPropertyKey, ObjectCreate(null));
+        }
         preventExtensions(shadowTarget);
     }
 
@@ -96,13 +99,20 @@ export abstract class BaseProxyHandler {
         return this.wrapValue(value);
     }
     has(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): boolean {
-        const { originalTarget, membrane: { valueObserved } } = this;
+        const { originalTarget, membrane: { tagPropertyKey, valueObserved } } = this;
         valueObserved(originalTarget, key);
-        return key in originalTarget;
+        // since key is never going to be undefined, and tagPropertyKey might be undefined
+        // we can simply compare them as the second part of the condition.
+        return key in originalTarget || key === tagPropertyKey;
     }
-    ownKeys(shadowTarget: ReactiveMembraneShadowTarget): string[] {
-        const { originalTarget } = this;
-        return ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
+    ownKeys(shadowTarget: ReactiveMembraneShadowTarget): PropertyKey[] {
+        const { originalTarget, membrane: { tagPropertyKey } } = this;
+        // if the membrane tag key exists and it is not in the original target, we add it to the keys.
+        const keys = isUndefined(tagPropertyKey) || hasOwnProperty.call(originalTarget, tagPropertyKey) ? [] : [tagPropertyKey];
+        // small perf optimization using push instead of concat to avoid creating an extra array
+        ArrayPush.apply(keys, getOwnPropertyNames(originalTarget));
+        ArrayPush.apply(keys, getOwnPropertySymbols(originalTarget));
+        return keys;
     }
     isExtensible(shadowTarget: ReactiveMembraneShadowTarget): boolean {
         const { originalTarget } = this;
@@ -121,16 +131,20 @@ export abstract class BaseProxyHandler {
         return getPrototypeOf(originalTarget);
     }
     getOwnPropertyDescriptor(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
-        const { originalTarget, membrane: { valueObserved } } = this;
+        const { originalTarget, membrane: { valueObserved, tagPropertyKey } } = this;
 
         // keys looked up via getOwnPropertyDescriptor need to be reactive
         valueObserved(originalTarget, key);
 
-        const desc = getOwnPropertyDescriptor(originalTarget, key);
+        let desc = getOwnPropertyDescriptor(originalTarget, key);
         if (isUndefined(desc)) {
-            return undefined;
+            if (key !== tagPropertyKey) {
+                return undefined;
+            }
+            // if the key is the membrane tag key, and is not in the original target,
+            // we produce a synthetic descriptor
+            desc = { value: undefined, writable: false, configurable: false, enumerable: false };
         }
-
         if (desc.configurable === false) {
             // updating the descriptor to non-configurable on the shadow
             this.copyDescriptorIntoShadowTarget(shadowTarget, key);

--- a/src/reactive-handler.ts
+++ b/src/reactive-handler.ts
@@ -122,13 +122,15 @@ export class ReactiveProxyHandler extends BaseProxyHandler {
     }
     defineProperty(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey, descriptor: PropertyDescriptor): boolean {
         const { originalTarget, membrane: { valueMutated, tagPropertyKey } } = this;
-        // To avoid leaking the membrane tag property into the original target, we must
-        // be sure that the original target doesn't have yet
-        if (key !== tagPropertyKey || hasOwnProperty.call(originalTarget, key)) {
-            // in the future, we could use Reflect.defineProperty to know the result of the operation
-            // for now, we assume it was carry on (if originalTarget is a proxy, it could reject the operation)
-            ObjectDefineProperty(originalTarget, key, this.unwrapDescriptor(descriptor));
+        if (key === tagPropertyKey && !hasOwnProperty.call(originalTarget, key)) {
+            // To avoid leaking the membrane tag property into the original target, we must
+            // be sure that the original target doesn't have yet.
+            // NOTE: we do not return false here because Object.freeze and equivalent operations
+            // will attempt to set the descriptor to the same value, and expect no to throw. This
+            // is an small compromise for the sake of not having to diff the descriptors.
+            return true;
         }
+        ObjectDefineProperty(originalTarget, key, this.unwrapDescriptor(descriptor));
         // intentionally testing if false since it could be undefined as well
         if (descriptor.configurable === false) {
             this.copyDescriptorIntoShadowTarget(shadowTarget, key);

--- a/src/reactive-handler.ts
+++ b/src/reactive-handler.ts
@@ -121,10 +121,14 @@ export class ReactiveProxyHandler extends BaseProxyHandler {
         return true;
     }
     defineProperty(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey, descriptor: PropertyDescriptor): boolean {
-        const { originalTarget, membrane: { valueMutated } } = this;
-        // in the future, we could use Reflect.defineProperty to know the result of the operation
-        // for now, we assume it was carry on (if originalTarget is a proxy, it could reject the operation)
-        ObjectDefineProperty(originalTarget, key, this.unwrapDescriptor(descriptor));
+        const { originalTarget, membrane: { valueMutated, tagPropertyKey } } = this;
+        // To avoid leaking the membrane tag property into the original target, we must
+        // be sure that the original target doesn't have yet
+        if (key !== tagPropertyKey || hasOwnProperty.call(originalTarget, key)) {
+            // in the future, we could use Reflect.defineProperty to know the result of the operation
+            // for now, we assume it was carry on (if originalTarget is a proxy, it could reject the operation)
+            ObjectDefineProperty(originalTarget, key, this.unwrapDescriptor(descriptor));
+        }
         // intentionally testing if false since it could be undefined as well
         if (descriptor.configurable === false) {
             this.copyDescriptorIntoShadowTarget(shadowTarget, key);

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -10,7 +10,6 @@ import {
 import { ReactiveProxyHandler } from './reactive-handler';
 import { ReadOnlyHandler } from './read-only-handler';
 import { init as initDevFormatter } from './reactive-dev-formatter';
-import { createShadowTarget } from './base-handler';
 
 if (process.env.NODE_ENV !== 'production') {
     initDevFormatter();
@@ -31,6 +30,7 @@ export interface ObservableMembraneInit {
     valueObserved?: ReactiveMembraneAccessCallback;
     valueDistortion?: ReactiveMembraneDistortionCallback;
     valueIsObservable?: ReactiveMembraneObservableCallback;
+    tagPropertyKey?: PropertyKey;
 }
 
 const ObjectDotPrototype = Object.prototype;
@@ -62,20 +62,26 @@ const defaultValueMutated: ReactiveMembraneMutationCallback = (obj: any, key: Pr
 };
 const defaultValueDistortion: ReactiveMembraneDistortionCallback = (value: any) => value;
 
+function createShadowTarget(value: any): any {
+    return isArray(value) ? [] : {};
+}
+
 export class ReactiveMembrane {
     valueDistortion: ReactiveMembraneDistortionCallback = defaultValueDistortion;
     valueMutated: ReactiveMembraneMutationCallback = defaultValueMutated;
     valueObserved: ReactiveMembraneAccessCallback = defaultValueObserved;
     valueIsObservable: ReactiveMembraneObservableCallback = defaultValueIsObservable;
+    tagPropertyKey: PropertyKey | undefined;
     private objectGraph: WeakMap<any, ReactiveState> = new WeakMap();
 
     constructor(options?: ObservableMembraneInit) {
         if (!isUndefined(options)) {
-            const { valueDistortion, valueMutated, valueObserved, valueIsObservable } = options;
+            const { valueDistortion, valueMutated, valueObserved, valueIsObservable, tagPropertyKey } = options;
             this.valueDistortion = isFunction(valueDistortion) ? valueDistortion : defaultValueDistortion;
             this.valueMutated = isFunction(valueMutated) ? valueMutated : defaultValueMutated;
             this.valueObserved = isFunction(valueObserved) ? valueObserved : defaultValueObserved;
             this.valueIsObservable = isFunction(valueIsObservable) ? valueIsObservable : defaultValueIsObservable;
+            this.tagPropertyKey = tagPropertyKey;
         }
     }
 

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -400,7 +400,6 @@ describe('ReactiveHandler', () => {
         const target = new ReactiveMembrane();
         const obj = { foo: 'bar' };
         const proxy = target.getProxy(obj);
-        debugger;
         Object.defineProperty(proxy, 'foo', {
             value: '',
             configurable: false,
@@ -925,7 +924,6 @@ describe('ReactiveHandler', () => {
             });
 
             const wet = target.getProxy(o);
-            debugger;
             Object.freeze(wet);
             expect(Object.getOwnPropertyNames(wet).length).toBe(1);
             expect('foo' in wet).toBe(true);

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -930,5 +930,14 @@ describe('ReactiveHandler', () => {
             expect('foo' in o).toBe(false);
             expect(wet.foo).toBe(undefined);
         });
+        it('should return the proper the descriptor for the magic prop', () => {
+            const o = {};
+            const target = new ReactiveMembrane({
+                tagPropertyKey: 'foo',
+            });
+
+            const wet = target.getProxy(o);
+            expect(Object.getOwnPropertyDescriptor(wet, 'foo')).toMatchObject({ value: undefined, enumerable: false, configurable: false, writable: false });
+        });
     });
 });

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -880,7 +880,7 @@ describe('ReactiveHandler', () => {
             });
         });
     });
-    describe('with magic key property', () => {
+    describe('with tag key property', () => {
         it('should support tagPropertyKey', () => {
             const o = {};
             const target = new ReactiveMembrane({
@@ -930,7 +930,7 @@ describe('ReactiveHandler', () => {
             expect('foo' in o).toBe(false);
             expect(wet.foo).toBe(undefined);
         });
-        it('should return the proper the descriptor for the magic prop', () => {
+        it('should return the proper the descriptor for the tag property', () => {
             const o = {};
             const target = new ReactiveMembrane({
                 tagPropertyKey: 'foo',

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -400,6 +400,7 @@ describe('ReactiveHandler', () => {
         const target = new ReactiveMembrane();
         const obj = { foo: 'bar' };
         const proxy = target.getProxy(obj);
+        debugger;
         Object.defineProperty(proxy, 'foo', {
             value: '',
             configurable: false,
@@ -873,12 +874,63 @@ describe('ReactiveHandler', () => {
             it('should notify on pop()', () => {
                 const value = ['foo', 'bar'];
                 const proxy = membrane.getProxy(value);
-                debugger;
                 expect(proxy.pop()).toBe('bar');
                 expect(changeSpy).toHaveBeenCalledTimes(2);
                 expect(changeSpy).toHaveBeenCalledWith(value, 'length');
                 expect(changeSpy).toHaveBeenCalledWith(value, '1');
             });
+        });
+    });
+    describe('with magic key property', () => {
+        it('should support tagPropertyKey', () => {
+            const o = {};
+            const target = new ReactiveMembrane({
+                tagPropertyKey: 'foo',
+            });
+
+            const wet = target.getProxy(o);
+            expect(Object.getOwnPropertyNames(wet).length).toBe(1);
+            expect('foo' in wet).toBe(true);
+            expect('foo' in o).toBe(false);
+            expect(wet.foo).toBe(undefined);
+        });
+        it('should not shadow tagPropertyKey if the target has it', () => {
+            const o = { foo: 1 };
+            const target = new ReactiveMembrane({
+                tagPropertyKey: 'foo',
+            });
+
+            const wet = target.getProxy(o);
+            expect(Object.getOwnPropertyNames(wet).length).toBe(1);
+            expect('foo' in wet).toBe(true);
+            expect('foo' in o).toBe(true);
+            expect(wet.foo).toBe(1);
+        });
+        it('should support frozen target when using tagPropertyKey', () => {
+            const o = Object.freeze({});
+            const target = new ReactiveMembrane({
+                tagPropertyKey: 'foo',
+            });
+
+            const wet = target.getProxy(o);
+            expect(Object.getOwnPropertyNames(wet).length).toBe(1);
+            expect('foo' in wet).toBe(true);
+            expect('foo' in o).toBe(false);
+            expect(wet.foo).toBe(undefined);
+        });
+        it('should support freezing the proxy when using tagPropertyKey', () => {
+            const o = {};
+            const target = new ReactiveMembrane({
+                tagPropertyKey: 'foo',
+            });
+
+            const wet = target.getProxy(o);
+            debugger;
+            Object.freeze(wet);
+            expect(Object.getOwnPropertyNames(wet).length).toBe(1);
+            expect('foo' in wet).toBe(true);
+            expect('foo' in o).toBe(false);
+            expect(wet.foo).toBe(undefined);
         });
     });
 });

--- a/test/reactive-membrane.spec.ts
+++ b/test/reactive-membrane.spec.ts
@@ -71,4 +71,40 @@ describe('constructor', () => {
         expect(blue.x).toBe(1);
         expect(red.doubleX()).toBe(2);
     });
+
+    it('should support undefined tagPropertyKey', () => {
+        const target = new ReactiveMembrane({
+            tagPropertyKey: undefined,
+        });
+
+        const wet = target.getProxy({});
+        expect(Object.getOwnPropertyNames(wet).length).toBe(0);
+    });
+
+    it('should support tagPropertyKey as string', () => {
+        const o = {};
+        const target = new ReactiveMembrane({
+            tagPropertyKey: 'foo',
+        });
+
+        const wet = target.getProxy(o);
+        expect(Object.getOwnPropertyNames(wet).length).toBe(1);
+        expect('foo' in wet).toBe(true);
+        expect('foo' in o).toBe(false);
+        expect(wet.foo).toBe(undefined);
+    });
+
+    it('should support tagPropertyKey as symbol', () => {
+        const o = {};
+        const k = Symbol();
+        const target = new ReactiveMembrane({
+            tagPropertyKey: k,
+        });
+
+        const wet = target.getProxy(o);
+        expect(Object.getOwnPropertySymbols(wet).length).toBe(1);
+        expect(k in wet).toBe(true);
+        expect(k in o).toBe(false);
+        expect(wet.foo).toBe(undefined);
+    });
 });

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -399,7 +399,7 @@ describe('ReadOnlyHandler', () => {
             Object.setPrototypeOf(property.foo, {});
         }).toThrow();
     });
-    describe('with magic key property', () => {
+    describe('with tag key property', () => {
         it('should support tagPropertyKey', () => {
             const o = {};
             const target = new ReactiveMembrane({

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -399,4 +399,30 @@ describe('ReadOnlyHandler', () => {
             Object.setPrototypeOf(property.foo, {});
         }).toThrow();
     });
+    describe('with magic key property', () => {
+        it('should support tagPropertyKey', () => {
+            const o = {};
+            const target = new ReactiveMembrane({
+                tagPropertyKey: 'foo',
+            });
+
+            const wet = target.getReadOnlyProxy(o);
+            expect(Object.getOwnPropertyNames(wet).length).toBe(1);
+            expect('foo' in wet).toBe(true);
+            expect('foo' in o).toBe(false);
+            expect(wet.foo).toBe(undefined);
+        });
+        it('should not shadow tagPropertyKey if the target has it', () => {
+            const o = { foo: 1 };
+            const target = new ReactiveMembrane({
+                tagPropertyKey: 'foo',
+            });
+
+            const wet = target.getReadOnlyProxy(o);
+            expect(Object.getOwnPropertyNames(wet).length).toBe(1);
+            expect('foo' in wet).toBe(true);
+            expect('foo' in o).toBe(true);
+            expect(wet.foo).toBe(1);
+        });
+    });
 });


### PR DESCRIPTION
### Use Case

As a developer, I can add a mark to read-only and read/write proxies so I can identify those proxy objects without attempting to proxify them again.

### API

```js
const flag = Symbol();
const membrane = new ObservableMembrane({
    tagPropertyKey: flag,
});
```

This new configuration called `tagPropertyKey` is optional, and if provided, it is expected to be a `PropertyKey` (string or symbol).

### Semantics

When `tagPropertyKey` configuration is provided, any read-only and read/write proxy created by the membrane will "contain" an own property with that name. E.g.:

```js
flag in proxy; // yields true
Reflect.has(proxy, flag); // yields true
proxy[flag]; // yields undefined
Object.getOwnPropertyDescriptor(proxy, flag); // { value: undefined, writable: false, configurable: false, enumerable: false }
```