### PR TITLE
fix: membrane consolidation to work with env virtualization

### DIFF
--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -38,6 +38,8 @@ export abstract class BaseProxyHandler {
     constructor(membrane: ReactiveMembrane, value: any) {
         this.originalTarget = value;
         this.membrane = membrane;
+        // future proxy optimizations
+        freeze(this);
     }
 
     // Abstract utility methods

--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -1,0 +1,175 @@
+import {
+    ArrayConcat,
+    getPrototypeOf,
+    getOwnPropertyNames,
+    getOwnPropertySymbols,
+    getOwnPropertyDescriptor,
+    isUndefined,
+    isExtensible,
+    hasOwnProperty,
+    unwrap,
+    ObjectDefineProperty,
+    preventExtensions,
+    isArray,
+    isObject,
+    freeze,
+} from './shared';
+import { ReactiveMembrane } from './reactive-membrane';
+
+export type ReactiveMembraneShadowTarget = object | any[];
+
+export function createShadowTarget(value: any): ReactiveMembraneShadowTarget {
+    let shadowTarget: ReactiveMembraneShadowTarget | undefined = undefined;
+    if (isArray(value)) {
+        shadowTarget = [];
+    } else if (isObject(value)) {
+        shadowTarget = {};
+    }
+    return shadowTarget as ReactiveMembraneShadowTarget;
+}
+
+const reserveGetterMap = new WeakMap<() => any, () => any>();
+const reverseSetterMap = new WeakMap<(v: any) => void, (v: any) => void>();
+
+export abstract class BaseProxyHandler {
+    originalTarget: any;
+    membrane: ReactiveMembrane;
+
+    constructor(membrane: ReactiveMembrane, value: any) {
+        this.originalTarget = value;
+        this.membrane = membrane;
+    }
+
+    // Abstract utility methods
+
+    abstract wrapValue(value: any): any;
+    abstract wrapGetter(originalGet: () => any): () => any;
+    abstract wrapSetter(originalSet: (v: any) => void): (v: any) => void;
+
+    // Shared utility methods
+
+    wrapDescriptor(descriptor: PropertyDescriptor): PropertyDescriptor {
+        if (hasOwnProperty.call(descriptor, 'value')) {
+            descriptor.value = this.wrapValue(descriptor.value);
+        } else {
+            const { set: originalSet, get: originalGet } = descriptor;
+            if (!isUndefined(originalGet)) {
+                const get = this.wrapGetter(originalGet);
+                reserveGetterMap.set(get, originalGet);
+                descriptor.get = get;
+            }
+            if (!isUndefined(originalSet)) {
+                const set = this.wrapSetter(originalSet);
+                reverseSetterMap.set(set, originalSet);
+                descriptor.set = set;
+            }
+        }
+        return descriptor;
+    }
+    unwrapDescriptor(descriptor: PropertyDescriptor): PropertyDescriptor {
+        if (hasOwnProperty.call(descriptor, 'value')) {
+            // dealing with a data descriptor
+            descriptor.value = unwrap(descriptor.value);
+        } else {
+            const { set, get } = descriptor;
+            if (!isUndefined(get)) {
+                descriptor.get = reserveGetterMap.get(get) || get;
+            }
+            if (!isUndefined(set)) {
+                descriptor.set = reverseSetterMap.get(set) || set;
+            }
+        }
+        return descriptor;
+    }
+    copyDescriptorIntoShadowTarget(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey) {
+        const { originalTarget } = this;
+        // Note: a property might get defined multiple times in the shadowTarget
+        //       but it will always be compatible with the previous descriptor
+        //       to preserve the object invariants, which makes these lines safe.
+        const originalDescriptor = getOwnPropertyDescriptor(originalTarget, key);
+        if (!isUndefined(originalDescriptor)) {
+            const wrappedDesc = this.wrapDescriptor(originalDescriptor);
+            ObjectDefineProperty(shadowTarget, key, wrappedDesc);
+        }
+    }
+    lockShadowTarget(shadowTarget: ReactiveMembraneShadowTarget): void {
+        const { originalTarget } = this;
+        const targetKeys = ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
+        targetKeys.forEach((key: PropertyKey) => {
+            this.copyDescriptorIntoShadowTarget(shadowTarget, key);
+        });
+        preventExtensions(shadowTarget);
+    }
+
+    // Abstract Traps
+
+    abstract set(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey, value: any): boolean;
+    abstract deleteProperty(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): boolean;
+    abstract setPrototypeOf(shadowTarget: ReactiveMembraneShadowTarget, prototype: any): any;
+    abstract preventExtensions(shadowTarget: ReactiveMembraneShadowTarget): boolean;
+    abstract defineProperty(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey, descriptor: PropertyDescriptor): boolean;
+
+    // Shared Traps
+
+    apply(shadowTarget: ReactiveMembraneShadowTarget, thisArg: any, argArray: any[]) {
+        /* No op */
+    }
+    construct(shadowTarget: ReactiveMembraneShadowTarget, argArray: any, newTarget?: any): any {
+        /* No op */
+    }
+    get(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): any {
+        const { originalTarget, membrane } = this;
+        const value = originalTarget[key];
+        const { valueObserved } = membrane;
+        valueObserved(originalTarget, key);
+        return this.wrapValue(value);
+    }
+    has(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): boolean {
+        const { originalTarget, membrane: { valueObserved } } = this;
+        valueObserved(originalTarget, key);
+        return key in originalTarget;
+    }
+    ownKeys(shadowTarget: ReactiveMembraneShadowTarget): string[] {
+        const { originalTarget } = this;
+        return ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
+    }
+    isExtensible(shadowTarget: ReactiveMembraneShadowTarget): boolean {
+        const { originalTarget } = this;
+        // optimization to avoid attempting to lock down the shadowTarget multiple times
+        if (!isExtensible(shadowTarget)) {
+            return false; // was already locked down
+        }
+        if (!isExtensible(originalTarget)) {
+            this.lockShadowTarget(shadowTarget);
+            return false;
+        }
+        return true;
+    }
+    getPrototypeOf(shadowTarget: ReactiveMembraneShadowTarget): object {
+        const { originalTarget } = this;
+        return getPrototypeOf(originalTarget);
+    }
+    getOwnPropertyDescriptor(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
+        const { originalTarget, membrane: { valueObserved } } = this;
+
+        // keys looked up via getOwnPropertyDescriptor need to be reactive
+        valueObserved(originalTarget, key);
+
+        const desc = getOwnPropertyDescriptor(originalTarget, key);
+        if (isUndefined(desc)) {
+            return undefined;
+        }
+
+        if (desc.configurable === false) {
+            // updating the descriptor to non-configurable on the shadow
+            this.copyDescriptorIntoShadowTarget(shadowTarget, key);
+        }
+        // Note: by accessing the descriptor, the key is marked as observed
+        // but access to the value, setter or getter (if available) cannot observe
+        // mutations, just like regular methods, in which case we just do nothing.
+        return this.wrapDescriptor(desc);
+    }
+}
+
+// future proxy optimizations
+freeze(BaseProxyHandler.prototype);

--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -10,7 +10,6 @@ import {
     ObjectDefineProperty,
     preventExtensions,
     isArray,
-    isObject,
     freeze,
 } from './shared';
 import { ReactiveMembrane } from './reactive-membrane';
@@ -18,13 +17,7 @@ import { ReactiveMembrane } from './reactive-membrane';
 export type ReactiveMembraneShadowTarget = object;
 
 export function createShadowTarget(value: any): ReactiveMembraneShadowTarget {
-    let shadowTarget: ReactiveMembraneShadowTarget | undefined = undefined;
-    if (isArray(value)) {
-        shadowTarget = [];
-    } else if (isObject(value)) {
-        shadowTarget = {};
-    }
-    return shadowTarget as ReactiveMembraneShadowTarget;
+    return isArray(value) ? [] : {};
 }
 
 export abstract class BaseProxyHandler {

--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -45,13 +45,10 @@ export abstract class BaseProxyHandler {
         } else {
             const { set: originalSet, get: originalGet } = descriptor;
             if (!isUndefined(originalGet)) {
-                const get = this.wrapGetter(originalGet);
-                
-                descriptor.get = get;
+                descriptor.get = this.wrapGetter(originalGet);;
             }
             if (!isUndefined(originalSet)) {
-                const set = this.wrapSetter(originalSet);
-                descriptor.set = set;
+                descriptor.set = this.wrapSetter(originalSet);
             }
         }
         return descriptor;

--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -15,7 +15,7 @@ import {
 } from './shared';
 import { ReactiveMembrane } from './reactive-membrane';
 
-export type ReactiveMembraneShadowTarget = object | any[];
+export type ReactiveMembraneShadowTarget = object;
 
 export function createShadowTarget(value: any): ReactiveMembraneShadowTarget {
     let shadowTarget: ReactiveMembraneShadowTarget | undefined = undefined;
@@ -100,9 +100,8 @@ export abstract class BaseProxyHandler {
         /* No op */
     }
     get(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): any {
-        const { originalTarget, membrane } = this;
+        const { originalTarget, membrane: { valueObserved } } = this;
         const value = originalTarget[key];
-        const { valueObserved } = membrane;
         valueObserved(originalTarget, key);
         return this.wrapValue(value);
     }

--- a/src/reactive-handler.ts
+++ b/src/reactive-handler.ts
@@ -38,7 +38,7 @@ export class ReactiveProxyHandler implements MembraneProxyHandler {
             return getterMap.get(originalGet) as () => any;
         }
         const handler = this;
-        function get(this: any): any {
+        const get = function (this: any): any {
             // invoking the original getter with the original target
             return handler.wrapValue(originalGet.call(unwrap(this)));
         };
@@ -50,7 +50,7 @@ export class ReactiveProxyHandler implements MembraneProxyHandler {
             return setterMap.get(originalSet) as (v: any) => void;
         }
         const handler = this;
-        function set(this: any, v: any) {
+        const set = function (this: any, v: any) {
             // invoking the original setter with the original target
             handler.wrapValue(originalSet.call(unwrap(this), v));
         };

--- a/src/reactive-handler.ts
+++ b/src/reactive-handler.ts
@@ -1,67 +1,61 @@
 import {
     toString,
-    isUndefined,
-    unwrap,
     ArrayConcat,
     isArray,
-    ObjectDefineProperty,
     getPrototypeOf,
-    isExtensible,
-    getOwnPropertyDescriptor,
     getOwnPropertyNames,
     getOwnPropertySymbols,
-    preventExtensions,
-    hasOwnProperty,
+    unwrap,
 } from './shared';
 
 import {
     ReactiveMembrane,
     ReactiveMembraneShadowTarget,
-    wrapDescriptor,
+    isExtensibleMembraneTrap,
+    getOwnPropertyDescriptorMembraneTrap,
+    definePropertyMembraneTrap,
+    preventExtensionsMembraneTrap,
+    MembraneProxyHandler,
 } from './reactive-membrane';
 
-function wrapValue(membrane: ReactiveMembrane, value: any): any {
-    return membrane.valueIsObservable(value) ? membrane.getProxy(value) : value;
-}
+const getterMap = new WeakMap<() => any, () => any>();
+const setterMap = new WeakMap<(v: any) => void, (v: any) => void>();
 
-/**
- * Unwrap property descriptors will set value on original descriptor
- * We only need to unwrap if value is specified
- * @param descriptor external descrpitor provided to define new property on original value
- */
-function unwrapDescriptor(descriptor: PropertyDescriptor): PropertyDescriptor {
-    if (hasOwnProperty.call(descriptor, 'value')) {
-        descriptor.value = unwrap(descriptor.value);
-    }
-    return descriptor;
-}
-
-function lockShadowTarget(membrane: ReactiveMembrane, shadowTarget: ReactiveMembraneShadowTarget, originalTarget: any): void {
-    const targetKeys = ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
-    targetKeys.forEach((key: PropertyKey) => {
-        let descriptor = getOwnPropertyDescriptor(originalTarget, key) as PropertyDescriptor;
-
-        // We do not need to wrap the descriptor if configurable
-        // Because we can deal with wrapping it when user goes through
-        // Get own property descriptor. There is also a chance that this descriptor
-        // could change sometime in the future, so we can defer wrapping
-        // until we need to
-        if (!descriptor.configurable) {
-            descriptor = wrapDescriptor(membrane, descriptor, wrapValue);
-        }
-        ObjectDefineProperty(shadowTarget, key, descriptor);
-    });
-
-    preventExtensions(shadowTarget);
-}
-
-export class ReactiveProxyHandler {
-    private originalTarget: any;
-    private membrane: ReactiveMembrane;
+export class ReactiveProxyHandler implements MembraneProxyHandler {
+    originalTarget: any;
+    membrane: ReactiveMembrane;
 
     constructor(membrane: ReactiveMembrane, value: any) {
         this.originalTarget = value;
         this.membrane = membrane;
+    }
+    wrapValue(value: any): any {
+        const { membrane } = this;
+        return membrane.valueIsObservable(value) ? membrane.getProxy(value) : value;
+    }
+    wrapGetter(originalGet: () => any): () => any {
+        if (getterMap.has(originalGet)) {
+            return getterMap.get(originalGet) as () => any;
+        }
+        const handler = this;
+        function get(this: any): any {
+            // invoking the original getter with the original target
+            return handler.wrapValue(originalGet.call(unwrap(this)));
+        };
+        getterMap.set(originalGet, get);
+        return get;
+    }
+    wrapSetter(originalSet: (v: any) => void): (v: any) => void {
+        if (setterMap.has(originalSet)) {
+            return setterMap.get(originalSet) as (v: any) => void;
+        }
+        const handler = this;
+        function set(this: any, v: any) {
+            // invoking the original setter with the original target
+            handler.wrapValue(originalSet.call(unwrap(this), v));
+        };
+        setterMap.set(originalSet, set);
+        return set;
     }
     get(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): any {
         const { originalTarget, membrane } = this;
@@ -94,7 +88,7 @@ export class ReactiveProxyHandler {
     apply(shadowTarget: ReactiveMembraneShadowTarget, thisArg: any, argArray: any[]) {
         /* No op */
     }
-    construct(target: ReactiveMembraneShadowTarget, argArray: any, newTarget?: any): any {
+    construct(shadowTarget: ReactiveMembraneShadowTarget, argArray: any, newTarget?: any): any {
         /* No op */
     }
     has(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): boolean {
@@ -107,20 +101,7 @@ export class ReactiveProxyHandler {
         return ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
     }
     isExtensible(shadowTarget: ReactiveMembraneShadowTarget): boolean {
-        const shadowIsExtensible = isExtensible(shadowTarget);
-
-        if (!shadowIsExtensible) {
-            return shadowIsExtensible;
-        }
-
-        const { originalTarget, membrane } = this;
-        const targetIsExtensible = isExtensible(originalTarget);
-
-        if (!targetIsExtensible) {
-            lockShadowTarget(membrane, shadowTarget, originalTarget);
-        }
-
-        return targetIsExtensible;
+        return isExtensibleMembraneTrap.call(this, shadowTarget);
     }
     setPrototypeOf(shadowTarget: ReactiveMembraneShadowTarget, prototype: any): any {
         if (process.env.NODE_ENV !== 'production') {
@@ -132,62 +113,12 @@ export class ReactiveProxyHandler {
         return getPrototypeOf(originalTarget);
     }
     getOwnPropertyDescriptor(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey): PropertyDescriptor | undefined {
-        const { originalTarget, membrane } = this;
-        const { valueObserved } = this.membrane;
-
-        // keys looked up via hasOwnProperty need to be reactive
-        valueObserved(originalTarget, key);
-
-        let desc = getOwnPropertyDescriptor(originalTarget, key);
-        if (isUndefined(desc)) {
-            return desc;
-        }
-        const shadowDescriptor = getOwnPropertyDescriptor(shadowTarget, key);
-        if (!isUndefined(shadowDescriptor)) {
-            return shadowDescriptor;
-        }
-        // Note: by accessing the descriptor, the key is marked as observed
-        // but access to the value, setter or getter (if available) cannot observe
-        // mutations, just like regular methods, in which case we just do nothing.
-        desc = wrapDescriptor(membrane, desc, wrapValue);
-        if (!desc.configurable) {
-            // If descriptor from original target is not configurable,
-            // We must copy the wrapped descriptor over to the shadow target.
-            // Otherwise, proxy will throw an invariant error.
-            // This is our last chance to lock the value.
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor#Invariants
-            ObjectDefineProperty(shadowTarget, key, desc);
-        }
-        return desc;
+        return getOwnPropertyDescriptorMembraneTrap.call(this, shadowTarget, key);
     }
     preventExtensions(shadowTarget: ReactiveMembraneShadowTarget): boolean {
-        const { originalTarget, membrane } = this;
-        lockShadowTarget(membrane, shadowTarget, originalTarget);
-        preventExtensions(originalTarget);
-        return true;
+        return preventExtensionsMembraneTrap.call(this, shadowTarget);
     }
     defineProperty(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey, descriptor: PropertyDescriptor): boolean {
-        const { originalTarget, membrane } = this;
-        const { valueMutated } = membrane;
-        const { configurable } = descriptor;
-
-        // We have to check for value in descriptor
-        // because Object.freeze(proxy) calls this method
-        // with only { configurable: false, writeable: false }
-        // Additionally, method will only be called with writeable:false
-        // if the descriptor has a value, as opposed to getter/setter
-        // So we can just check if writable is present and then see if
-        // value is present. This eliminates getter and setter descriptors
-        if (hasOwnProperty.call(descriptor, 'writable') && !hasOwnProperty.call(descriptor, 'value')) {
-            const originalDescriptor = getOwnPropertyDescriptor(originalTarget, key) as PropertyDescriptor;
-            descriptor.value = originalDescriptor.value;
-        }
-        ObjectDefineProperty(originalTarget, key, unwrapDescriptor(descriptor));
-        if (configurable === false) {
-            ObjectDefineProperty(shadowTarget, key, wrapDescriptor(membrane, descriptor, wrapValue));
-        }
-
-        valueMutated(originalTarget, key);
-        return true;
+        return definePropertyMembraneTrap.call(this, shadowTarget, key, descriptor);
     }
 }

--- a/src/reactive-handler.ts
+++ b/src/reactive-handler.ts
@@ -1,14 +1,10 @@
 import { toString, isArray, unwrap, isExtensible, preventExtensions, ObjectDefineProperty, freeze } from './shared';
-import { ReactiveMembrane } from './reactive-membrane';
 import { BaseProxyHandler, ReactiveMembraneShadowTarget } from './base-handler';
 
 const getterMap = new WeakMap<() => any, () => any>();
 const setterMap = new WeakMap<(v: any) => void, (v: any) => void>();
 
 export class ReactiveProxyHandler extends BaseProxyHandler {
-    constructor(membrane: ReactiveMembrane, value: any) {
-        super(membrane, value);
-    }
     wrapValue(value: any): any {
         return this.membrane.getProxy(value);
     }

--- a/src/reactive-handler.ts
+++ b/src/reactive-handler.ts
@@ -52,7 +52,7 @@ export class ReactiveProxyHandler implements MembraneProxyHandler {
         const handler = this;
         const set = function (this: any, v: any) {
             // invoking the original setter with the original target
-            handler.wrapValue(originalSet.call(unwrap(this), v));
+            originalSet.call(unwrap(this), unwrap(v));
         };
         setterMap.set(originalSet, set);
         return set;

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -8,6 +8,12 @@ import {
     isFunction,
     hasOwnProperty,
     registerProxy,
+    preventExtensions,
+    ArrayConcat,
+    getOwnPropertyNames,
+    getOwnPropertySymbols,
+    getOwnPropertyDescriptor,
+    isExtensible,
 } from './shared';
 import { ReactiveProxyHandler } from './reactive-handler';
 import { ReadOnlyHandler } from './read-only-handler';
@@ -35,6 +41,14 @@ export interface ObservableMembraneInit {
     valueObserved?: ReactiveMembraneAccessCallback;
     valueDistortion?: ReactiveMembraneDistortionCallback;
     valueIsObservable?: ReactiveMembraneObservableCallback;
+}
+
+export interface MembraneProxyHandler extends ProxyHandler<any> {
+    originalTarget: any;
+    membrane: ReactiveMembrane;
+    wrapValue(v: any): any;
+    wrapGetter(get: () => any): () => any;
+    wrapSetter(set: (v: any) => void): (v: any) => void;
 }
 
 function createShadowTarget(value: any): ReactiveMembraneShadowTarget {
@@ -76,29 +90,148 @@ const defaultValueMutated: ReactiveMembraneMutationCallback = (obj: any, key: Pr
 };
 const defaultValueDistortion: ReactiveMembraneDistortionCallback = (value: any) => value;
 
-export function wrapDescriptor(membrane: ReactiveMembrane, descriptor: PropertyDescriptor, getValue: (membrane: ReactiveMembrane, originalValue: any) => any): PropertyDescriptor {
-    const { set, get } = descriptor;
+const reserveGetterMap = new WeakMap<() => any, () => any>();
+const reverseSetterMap = new WeakMap<(v: any) => void, (v: any) => void>();
+
+export function wrapDescriptor(handler: MembraneProxyHandler, descriptor: PropertyDescriptor): PropertyDescriptor {
     if (hasOwnProperty.call(descriptor, 'value')) {
-        descriptor.value = getValue(membrane, descriptor.value);
+        descriptor.value = handler.wrapValue(descriptor.value);
     } else {
-        if (!isUndefined(get)) {
-            descriptor.get = function() {
-                // invoking the original getter with the original target
-                return getValue(membrane, get.call(unwrap(this)));
-            };
+        const { set: originalSet, get: originalGet } = descriptor;
+        if (!isUndefined(originalGet)) {
+            const get = handler.wrapGetter(originalGet);
+            reserveGetterMap.set(get, originalGet);
+            descriptor.get = get;
         }
-        if (!isUndefined(set)) {
-            descriptor.set = function(value) {
-                // At this point we don't have a clear indication of whether
-                // or not a valid mutation will occur, we don't have the key,
-                // and we are not sure why and how they are invoking this setter.
-                // Nevertheless we preserve the original semantics by invoking the
-                // original setter with the original target and the unwrapped value
-                set.call(unwrap(this), membrane.unwrapProxy(value));
-            };
+        if (!isUndefined(originalSet)) {
+            const set = handler.wrapSetter(originalSet);
+            reverseSetterMap.set(set, originalSet);
+            descriptor.set = set;
         }
     }
     return descriptor;
+}
+
+export function unwrapDescriptor(handler: MembraneProxyHandler, descriptor: PropertyDescriptor): PropertyDescriptor {
+    if (hasOwnProperty.call(descriptor, 'value')) {
+        // dealing with a data descriptor
+        descriptor.value = unwrap(descriptor.value);
+    } else {
+        const { set, get } = descriptor;
+        if (!isUndefined(get)) {
+            descriptor.get = reserveGetterMap.get(get) || get;
+        }
+        if (!isUndefined(set)) {
+            descriptor.set = reverseSetterMap.get(set) || set;
+        }
+    }
+    return descriptor;
+}
+
+export function copyDescriptorIntoShadowTarget(
+    handler: MembraneProxyHandler,
+    shadowTarget: ReactiveMembraneShadowTarget,
+    key: PropertyKey,
+) {
+    const { originalTarget } = handler;
+    // Note: a property might get defined multiple times in the shadowTarget
+    //       but it will always be compatible with the previous descriptor
+    //       to preserve the object invariants, which makes these lines safe.
+    const normalizedDescriptor = getOwnPropertyDescriptor(originalTarget, key);
+    if (!isUndefined(normalizedDescriptor)) {
+        const blueDesc = wrapDescriptor(handler, normalizedDescriptor);
+        ObjectDefineProperty(shadowTarget, key, blueDesc);
+    }
+}
+
+export function lockShadowTarget(
+    handler: MembraneProxyHandler,
+    shadowTarget: ReactiveMembraneShadowTarget
+): void {
+    const { originalTarget } = handler;
+    const targetKeys = ArrayConcat.call(getOwnPropertyNames(originalTarget), getOwnPropertySymbols(originalTarget));
+    targetKeys.forEach((key: PropertyKey) => {
+        copyDescriptorIntoShadowTarget(handler, shadowTarget, key);
+    });
+
+    preventExtensions(shadowTarget);
+}
+
+export function isExtensibleMembraneTrap(
+    this: MembraneProxyHandler,
+    shadowTarget: ReactiveMembraneShadowTarget
+): boolean {
+    const { originalTarget } = this;
+    // optimization to avoid attempting to lock down the shadowTarget multiple times
+    if (!isExtensible(shadowTarget)) {
+        return false; // was already locked down
+    }
+    if (!isExtensible(originalTarget)) {
+        lockShadowTarget(this, shadowTarget);
+        return false;
+    }
+    return true;
+}
+
+export function getOwnPropertyDescriptorMembraneTrap(
+    this: MembraneProxyHandler,
+    shadowTarget: ReactiveMembraneShadowTarget,
+    key: PropertyKey
+): PropertyDescriptor | undefined {
+    const { originalTarget, membrane: { valueObserved } } = this;
+
+    // keys looked up via hasOwnProperty need to be reactive
+    valueObserved(originalTarget, key);
+
+    const desc = getOwnPropertyDescriptor(originalTarget, key);
+    if (isUndefined(desc)) {
+        return desc;
+    }
+
+    if (desc.configurable === false) {
+        // updating the descriptor to non-configurable on the shadow
+        copyDescriptorIntoShadowTarget(this, shadowTarget, key);
+    }
+    // Note: by accessing the descriptor, the key is marked as observed
+    // but access to the value, setter or getter (if available) cannot observe
+    // mutations, just like regular methods, in which case we just do nothing.
+    return wrapDescriptor(this, desc);
+}
+
+export function preventExtensionsMembraneTrap(
+    this: MembraneProxyHandler,
+    shadowTarget: ReactiveMembraneShadowTarget
+): boolean {
+    const { originalTarget } = this;
+    if (isExtensible(shadowTarget)) {
+        preventExtensions(originalTarget);
+        // if the originalTarget is a proxy itself, it might reject
+        // the preventExtension call, in which case we should not attempt to lock down
+        // the shadow target.
+        if (isExtensible(originalTarget)) {
+            return false;
+        }
+        lockShadowTarget(this, shadowTarget);
+    }
+    return true;
+}
+
+export function definePropertyMembraneTrap(
+    this: MembraneProxyHandler,
+    shadowTarget: ReactiveMembraneShadowTarget,
+    key: PropertyKey,
+    descriptor: PropertyDescriptor
+): boolean {
+    const { originalTarget, membrane: { valueMutated } } = this;
+    // in the future, we could use Reflect.defineProperty to know the result of the operation
+    // for now, we assume it was carry on (if originalTarget is a proxy, it could reject the operation)
+    ObjectDefineProperty(originalTarget, key, unwrapDescriptor(this, descriptor));
+    // intentionally testing against true since it could be undefined as well
+    if (descriptor.configurable === false) {
+        copyDescriptorIntoShadowTarget(this, shadowTarget, key);
+    }
+    valueMutated(originalTarget, key);
+    return true;
 }
 
 export class ReactiveMembrane {

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -137,10 +137,10 @@ export function copyDescriptorIntoShadowTarget(
     // Note: a property might get defined multiple times in the shadowTarget
     //       but it will always be compatible with the previous descriptor
     //       to preserve the object invariants, which makes these lines safe.
-    const normalizedDescriptor = getOwnPropertyDescriptor(originalTarget, key);
-    if (!isUndefined(normalizedDescriptor)) {
-        const blueDesc = wrapDescriptor(handler, normalizedDescriptor);
-        ObjectDefineProperty(shadowTarget, key, blueDesc);
+    const originalDescriptor = getOwnPropertyDescriptor(originalTarget, key);
+    if (!isUndefined(originalDescriptor)) {
+        const wrappedDesc = wrapDescriptor(handler, originalDescriptor);
+        ObjectDefineProperty(shadowTarget, key, wrappedDesc);
     }
 }
 
@@ -180,12 +180,12 @@ export function getOwnPropertyDescriptorMembraneTrap(
 ): PropertyDescriptor | undefined {
     const { originalTarget, membrane: { valueObserved } } = this;
 
-    // keys looked up via hasOwnProperty need to be reactive
+    // keys looked up via getOwnPropertyDescriptor need to be reactive
     valueObserved(originalTarget, key);
 
     const desc = getOwnPropertyDescriptor(originalTarget, key);
     if (isUndefined(desc)) {
-        return desc;
+        return undefined;
     }
 
     if (desc.configurable === false) {

--- a/src/read-only-handler.ts
+++ b/src/read-only-handler.ts
@@ -34,7 +34,7 @@ export class ReadOnlyHandler implements MembraneProxyHandler {
             return getterMap.get(originalGet) as () => any;
         }
         const handler = this;
-        function get(this: any): any {
+        const get = function (this: any): any {
             // invoking the original getter with the original target
             return handler.wrapValue(originalGet.call(unwrap(this)));
         };
@@ -46,7 +46,7 @@ export class ReadOnlyHandler implements MembraneProxyHandler {
             return setterMap.get(originalSet) as (v: any) => void;
         }
         const handler = this;
-        function set(this: any, v: any) {
+        const set = function (this: any, v: any) {
             if (process.env.NODE_ENV !== 'production') {
                 const { originalTarget } = handler;
                 throw new Error(`Invalid mutation: Cannot invoke a setter on "${originalTarget}". "${originalTarget}" is read-only.`);

--- a/src/read-only-handler.ts
+++ b/src/read-only-handler.ts
@@ -1,4 +1,4 @@
-import { unwrap, freeze } from './shared';
+import { unwrap, freeze, isUndefined } from './shared';
 import { BaseProxyHandler, ReactiveMembraneShadowTarget } from './base-handler';
 
 const getterMap = new WeakMap<() => any, () => any>();
@@ -9,8 +9,9 @@ export class ReadOnlyHandler extends BaseProxyHandler {
         return this.membrane.getReadOnlyProxy(value);
     }
     wrapGetter(originalGet: () => any): () => any {
-        if (getterMap.has(originalGet)) {
-            return getterMap.get(originalGet) as () => any;
+        const wrappedGetter = getterMap.get(originalGet);
+        if (!isUndefined(wrappedGetter)) {
+            return wrappedGetter;
         }
         const handler = this;
         const get = function (this: any): any {
@@ -21,8 +22,9 @@ export class ReadOnlyHandler extends BaseProxyHandler {
         return get;
     }
     wrapSetter(originalSet: (v: any) => void): (v: any) => void {
-        if (setterMap.has(originalSet)) {
-            return setterMap.get(originalSet) as (v: any) => void;
+        const wrappedSetter = setterMap.get(originalSet);
+        if (!isUndefined(wrappedSetter)) {
+            return wrappedSetter;
         }
         const handler = this;
         const set = function (this: any, v: any) {

--- a/src/read-only-handler.ts
+++ b/src/read-only-handler.ts
@@ -1,14 +1,10 @@
 import { unwrap, freeze } from './shared';
-import { ReactiveMembrane } from './reactive-membrane';
 import { BaseProxyHandler, ReactiveMembraneShadowTarget } from './base-handler';
 
 const getterMap = new WeakMap<() => any, () => any>();
 const setterMap = new WeakMap<(v: any) => void, (v: any) => void>();
 
 export class ReadOnlyHandler extends BaseProxyHandler {
-    constructor(membrane: ReactiveMembrane, value: any) {
-        super(membrane, value);
-    }
     wrapValue(value: any): any {
         return this.membrane.getReadOnlyProxy(value);
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -11,6 +11,7 @@ const {
     getOwnPropertySymbols,
     preventExtensions,
     hasOwnProperty,
+    freeze,
 } = Object;
 
 const {
@@ -34,6 +35,7 @@ export {
     getOwnPropertySymbols,
     preventExtensions,
     hasOwnProperty,
+    freeze,
 };
 
 const OtS = {}.toString;

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -640,7 +640,6 @@ describe('ReactiveHandler', () => {
             const target = new ReactiveMembrane();
             const todos = {};
             let value = 0;
-            const newValue = {};
             function get() {
                 return value;
             }
@@ -664,11 +663,10 @@ describe('ReactiveHandler', () => {
         });
         it('should protect against leaking accessors into the blue side', () => {
             const target = new ReactiveMembrane();
-            const todos = {};
+            const todos: any = {};
             let value = 0;
             let getterThisValue = null;
             let setterThisValue = null;
-            const newValue = {};
             function get() {
                 getterThisValue = this;
                 return value;
@@ -687,8 +685,6 @@ describe('ReactiveHandler', () => {
             const proxyDesc = Object.getOwnPropertyDescriptor(proxy, 'entry');
             expect(proxyDesc.get).toEqual(get);
             expect(proxyDesc.set).toEqual(set);
-            expect(proxyDesc.get).toEqual(Object.getOwnPropertyDescriptor(proxy, 'entry').get);
-            expect(proxyDesc.set).toEqual(Object.getOwnPropertyDescriptor(proxy, 'entry').set);
             expect(proxy.entry).toBe(0);
             expect(getterThisValue).toBe(proxy);
             proxy.entry = 1;

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -636,6 +636,32 @@ describe('ReactiveHandler', () => {
             expect(todos.entry).toEqual(newValue);
             expect(proxy.entry).toEqual(get.call(proxy));
         });
+        it('should preserve the identity of the accessors', () => {
+            const target = new ReactiveMembrane();
+            const todos = {};
+            let value = 0;
+            const newValue = {};
+            function get() {
+                return value;
+            }
+            function set(v) {
+                value = v;
+            }
+            Object.defineProperty(todos, 'entry', {
+                get,
+                set,
+                configurable: true
+            });
+            const proxy = target.getProxy(todos);
+            const proxyDesc = Object.getOwnPropertyDescriptor(proxy, 'entry');
+            Object.defineProperty(proxy, 'newentry', proxyDesc);
+            const copiedDesc = Object.getOwnPropertyDescriptor(todos, 'newentry');
+            const proxyCopiedDesc = Object.getOwnPropertyDescriptor(proxy, 'newentry');
+            expect(copiedDesc.get).toEqual(get);
+            expect(copiedDesc.set).toEqual(set);
+            expect(proxyDesc.get).toEqual(proxyCopiedDesc.get);
+            expect(proxyDesc.set).toEqual(proxyCopiedDesc.set);
+        });
         it('should be reactive when descriptor is accessed', () => {
             let observedTarget;
             let observedKey;

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -701,6 +701,28 @@ describe('ReactiveHandler', () => {
             expect(proxy).not.toBe(value);
             expect(defaultMembrane.unwrapProxy(value)).toBe(value);
         });
+        it('access allow length mutations', () => {
+            const value = [];
+            const proxy = defaultMembrane.getProxy(value);
+            expect(Array.isArray(proxy)).toBe(true);
+            expect(proxy.length).toBe(0);
+            proxy.length = 1;
+            expect(proxy.length).toBe(1);
+            proxy[1] = 'another';
+            expect(proxy.length).toBe(2);
+            expect(proxy[1]).toBe('another');
+        });
+        it('access length descriptor', () => {
+            const value = [];
+            const proxy = defaultMembrane.getProxy(value);
+            expect(Array.isArray(proxy)).toBe(true);
+            expect(Object.getOwnPropertyDescriptor(proxy, 'length').value).toBe(0);
+            proxy.length = 1;
+            expect(Object.getOwnPropertyDescriptor(proxy, 'length').value).toBe(1);
+            proxy[1] = 'another';
+            expect(Object.getOwnPropertyDescriptor(proxy, 'length').value).toBe(2);
+            expect(proxy[1]).toBe('another');
+        });
         it('access items in array', () => {
             const value = ['foo', 'bar'];
             const proxy = defaultMembrane.getProxy(value);

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -327,6 +327,33 @@ describe('ReadOnlyHandler', () => {
             }).toThrow();
             expect(get.call(proxy)).toEqual(0);
         });
+        it('should preserve the identity of the accessors', () => {
+            const target = new ReactiveMembrane();
+            const todos = {};
+            let value = 0;
+            const newValue = {};
+            function get() {
+                return value;
+            }
+            function set(v) {
+                value = v;
+            }
+            Object.defineProperty(todos, 'entry', {
+                get,
+                set,
+                configurable: true
+            });
+            Object.defineProperty(todos, 'newentry', {
+                get,
+                set,
+                configurable: true
+            });
+            const proxy = target.getReadOnlyProxy(todos);
+            const proxyDesc = Object.getOwnPropertyDescriptor(proxy, 'entry');
+            const proxyCopiedDesc = Object.getOwnPropertyDescriptor(proxy, 'newentry');
+            expect(proxyDesc.get).toEqual(proxyCopiedDesc.get);
+            expect(proxyDesc.set).toEqual(proxyCopiedDesc.set);
+        });
         it('should be reactive when descriptor is accessed', () => {
             let observedTarget;
             let observedKey;

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -332,7 +332,6 @@ describe('ReadOnlyHandler', () => {
             const target = new ReactiveMembrane();
             const todos = {};
             let value = 0;
-            const newValue = {};
             function get() {
                 return value;
             }

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -71,7 +71,8 @@ describe('ReadOnlyHandler', () => {
 
         const property = target.getReadOnlyProxy(obj);
         const desc = Object.getOwnPropertyDescriptor(property, 'foo')!;
-        expect(target.getReadOnlyProxy(desc.get!())).toBe(property.foo);
+        expect(desc.get!.call(property)).toBe(property.foo);
+        expect(target.getReadOnlyProxy(desc.get!.call(property))).toBe(property.foo);
     });
     it('should handle has correctly', function() {
         const target = new ReactiveMembrane();


### PR DESCRIPTION
* never using the shadowTarget to read from it, it is only there for the invariants
* fix unwrapping of accessor descriptors
* moving shared code into a new BaseProxyHandler that shared 80% of the logic between the two handlers (this file actually have all the shadowTarget logic from membrane as well)