### PR TITLE
Improve errors for read-only array mutations

### DIFF
--- a/src/read-only-handler.ts
+++ b/src/read-only-handler.ts
@@ -1,4 +1,4 @@
-import { unwrap, isUndefined } from './shared';
+import { unwrap, isArray, isUndefined } from './shared';
 import { BaseProxyHandler, ReactiveMembraneShadowTarget } from './base-handler';
 
 const getterMap = new WeakMap<() => any, () => any>();
@@ -39,7 +39,10 @@ export class ReadOnlyHandler extends BaseProxyHandler {
     set(shadowTarget: ReactiveMembraneShadowTarget, key: PropertyKey, value: any): boolean {
         if (process.env.NODE_ENV !== 'production') {
             const { originalTarget } = this;
-            throw new Error(`Invalid mutation: Cannot set "${key.toString()}" on "${originalTarget}". "${originalTarget}" is read-only.`);
+            const msg = isArray(originalTarget) ?
+                `Invalid mutation: Cannot mutate array at index ${key.toString()}. Array is read-only.` :
+                `Invalid mutation: Cannot set "${key.toString()}" on "${originalTarget}". "${originalTarget}" is read-only.`;
+            throw new Error(msg);
         }
         return false;
     }

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -425,4 +425,14 @@ describe('ReadOnlyHandler', () => {
             expect(wet.foo).toBe(1);
         });
     });
+    it('should throw a helpful message when attempting to mutate an array', function () {
+        const target = new ReactiveMembrane();
+        const obj = [];
+        const property = target.getReadOnlyProxy(obj);
+        expect(() => {
+            property.push("some object");
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Invalid mutation: Cannot mutate array at index 0. Array is read-only."`
+        );
+    });
 });


### PR DESCRIPTION
This PR addresses the unhelpful error message discussed in salesforce/lwc#1739, when an attempt is made at mutating a read-only array.  Some discussion seems to have occurred offline that wasn't captured in the issue, so the preferred solution wasn't readily apparent.  Pinging  @apapko @pmdartus @caridy since they previously weighed in.

Before, if someone attempted to mutate a read-only array (using the LWC `@api` decorator, for example), they would be presented with the following error:

```
Error: Invalid mutation: Cannot set "0" on "". "" is read-only.
```

The error now reads:

```
Error: Invalid mutation: Cannot mutate array at index 0. Array is read-only.
```

The change addresses the specific concern that was raised but may be insufficient to address larger, related DX concerns.  Still, this seemed a reasonable resolution and submitting a PR seemed the easiest to facilitate discussion.  Happy to go in a different direction if that is preferred.