### PR TITLE
docs: point changelog to GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,3 @@
-<a name="0.26.0"></a>
-# 0.26.0 (2018-11-19)
+# Changelog
 
-
-### Bug Fixes
-
-* bundle generation for cjs ([78b420a](https://github.com/salesforce/observable-membrane/commit/78b420a))
-* entry point ([4231ecb](https://github.com/salesforce/observable-membrane/commit/4231ecb))
-* issue [#20](https://github.com/salesforce/observable-membrane/issues/20) - supporting access to value via descriptor ([#22](https://github.com/salesforce/observable-membrane/issues/22)) ([4bd4751](https://github.com/salesforce/observable-membrane/commit/4bd4751))
-* linting ([ac2d448](https://github.com/salesforce/observable-membrane/commit/ac2d448))
-* simplify build ([13bd2ee](https://github.com/salesforce/observable-membrane/commit/13bd2ee))
-
-
-### Features
-
-* **changelog:** add conventional changlog and first version of the changelog ([c37376c](https://github.com/salesforce/observable-membrane/commit/c37376c))
-
-
-### Performance Improvements
-
-* fix for small perf regression associated to defineProperties(). ([9c54ec0](https://github.com/salesforce/observable-membrane/commit/9c54ec0))
-
-
-
+See the [GitHub Releases page](https://github.com/salesforce/observable-membrane/releases) for the changelog.


### PR DESCRIPTION
The CHANGELOG.md hasn't been updated in years. I tagged the relevant releases and moved the existing release notes into GitHub Releases: https://github.com/salesforce/observable-membrane/releases . So now we can just have CHANGELOG.md point to GitHub Releases.