### PR TITLE
chore: fix publish process

### DIFF
--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -40,7 +40,7 @@ try {
         `Attempting to release from branch "${releaseBranch}" using dist-tag "${distTag}".`
     );
 
-    execa.commandSync(`npm publish --tag ${distTag}`);
+    execa.commandSync(`npm publish --tag ${distTag} --registry=https://registry.npmjs.org`);
 } catch (ex) {
     console.error(ex);
     process.exit(1);


### PR DESCRIPTION
It looks like the publishing process is [borked](https://app.circleci.com/pipelines/github/salesforce/observable-membrane/70/workflows/fdfb2c78-b6c0-4103-9051-9039ad09d9ba/jobs/210) because it's trying to publish to the yarn registry.

I believe this should fix it, although I can't actually test it without publishing. 😅  So I guess I'll just 🤞 .

```
$ ./scripts/release/publish.js
Attempting to release from branch "master" using dist-tag "next".
Error: Command failed with exit code 1: npm publish --tag next
npm notice 
npm notice 📦  observable-membrane@1.1.3
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE     
npm notice 2.0kB  package.json
npm notice 123B   CHANGELOG.md
npm notice 11.5kB README.md   
npm notice === Tarball Details === 
npm notice name:          observable-membrane                     
npm notice version:       1.1.3                                   
npm notice package size:  5.3 kB                                  
npm notice unpacked size: 14.7 kB                                 
npm notice shasum:        1277ba18587b4314dd04386e88475c3d0be27141
npm notice integrity:     sha512-MDOjJ/6QzAdYr[...]/aA83DTRNjhsg==
npm notice total files:   4                                       
npm notice 
npm ERR! code E404
npm ERR! 404 Not Found - PUT https://registry.yarnpkg.com/observable-membrane - Not found
npm ERR! 404 
npm ERR! 404  'observable-membrane@1.1.3' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```