### PR TITLE
perf: optimize reactive state handlers

### DIFF
--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -87,7 +87,7 @@ export class ReactiveMembrane {
             if (this.readOnlyObjectGraph.get(distorted) === value) {
                 // when trying to extract the writable version of a readonly
                 // we return the readonly.
-                return value
+                return value;
             }
             return this.getReactiveHandler(unwrappedValue, distorted, false);
         }

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -84,10 +84,12 @@ export class ReactiveMembrane {
         const unwrappedValue = unwrap(value);
         const distorted = this.valueDistortion(unwrappedValue);
         if (this.valueIsObservable(distorted)) {
-            const readOnly = this.getReactiveHandler(unwrappedValue, distorted, true);
-            // when trying to extract the writable version of a readonly
-            // we return the readonly.
-            return readOnly === value ? value : this.getReactiveHandler(unwrappedValue, distorted, false);
+            if (this.readOnlyObjectGraph.get(distorted) === value) {
+                // when trying to extract the writable version of a readonly
+                // we return the readonly.
+                return value
+            }
+            return this.getReactiveHandler(unwrappedValue, distorted, false);
         }
         return distorted;
     }

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -1,5 +1,4 @@
 import {
-    ObjectDefineProperty,
     unwrap,
     isArray,
     isUndefined,
@@ -13,11 +12,6 @@ import { init as initDevFormatter } from './reactive-dev-formatter';
 
 if (process.env.NODE_ENV !== 'production') {
     initDevFormatter();
-}
-
-interface ReactiveState {
-    readOnly: any;
-    reactive: any;
 }
 
 export type ReactiveMembraneAccessCallback = (obj: any, key: ProxyPropertyKey) => void;
@@ -72,7 +66,8 @@ export class ReactiveMembrane {
     valueObserved: ReactiveMembraneAccessCallback = defaultValueObserved;
     valueIsObservable: ReactiveMembraneObservableCallback = defaultValueIsObservable;
     tagPropertyKey: ProxyPropertyKey | undefined;
-    private objectGraph: WeakMap<any, ReactiveState> = new WeakMap();
+    private readOnlyObjectGraph: WeakMap<any, any> = new WeakMap();
+    private reactiveObjectGraph: WeakMap<any, any> = new WeakMap();
 
     constructor(options?: ObservableMembraneInit) {
         if (!isUndefined(options)) {
@@ -89,10 +84,10 @@ export class ReactiveMembrane {
         const unwrappedValue = unwrap(value);
         const distorted = this.valueDistortion(unwrappedValue);
         if (this.valueIsObservable(distorted)) {
-            const o = this.getReactiveState(unwrappedValue, distorted);
+            const readOnly = this.getReactiveHandler(unwrappedValue, distorted, true);
             // when trying to extract the writable version of a readonly
             // we return the readonly.
-            return o.readOnly === value ? value : o.reactive;
+            return readOnly === value ? value : this.getReactiveHandler(unwrappedValue, distorted, false);
         }
         return distorted;
     }
@@ -101,7 +96,7 @@ export class ReactiveMembrane {
         value = unwrap(value);
         const distorted = this.valueDistortion(value);
         if (this.valueIsObservable(distorted)) {
-            return this.getReactiveState(value, distorted).readOnly;
+            return this.getReactiveHandler(value, distorted, true);
         }
         return distorted;
     }
@@ -110,36 +105,18 @@ export class ReactiveMembrane {
         return unwrap(p);
     }
 
-    private getReactiveState(value: any, distortedValue: any): ReactiveState {
-        const {
-            objectGraph,
-        } = this;
-        let reactiveState = objectGraph.get(distortedValue);
-        if (reactiveState) {
-            return reactiveState;
+    private getReactiveHandler(value: any, distortedValue: any, readOnly: boolean): any {
+        const objectGraph = readOnly ? this.readOnlyObjectGraph : this.reactiveObjectGraph
+        let proxy = objectGraph.get(distortedValue);
+        if (isUndefined(proxy)) {
+            // caching the proxy after the first time it is accessed
+            const handler = readOnly
+                ? new ReadOnlyHandler(this, distortedValue)
+                : new ReactiveProxyHandler(this, distortedValue);
+            proxy = new Proxy(createShadowTarget(distortedValue), handler);
+            registerProxy(proxy, value);
+            objectGraph.set(distortedValue, proxy);
         }
-        const membrane = this;
-        reactiveState = {
-            get reactive() {
-                const reactiveHandler = new ReactiveProxyHandler(membrane, distortedValue);
-                // caching the reactive proxy after the first time it is accessed
-                const proxy = new Proxy(createShadowTarget(distortedValue), reactiveHandler);
-                registerProxy(proxy, value);
-                ObjectDefineProperty(this, 'reactive', { value: proxy });
-                return proxy;
-            },
-            get readOnly() {
-                const readOnlyHandler = new ReadOnlyHandler(membrane, distortedValue);
-                // caching the readOnly proxy after the first time it is accessed
-                const proxy = new Proxy(createShadowTarget(distortedValue), readOnlyHandler);
-                registerProxy(proxy, value);
-                ObjectDefineProperty(this, 'readOnly', { value: proxy });
-                return proxy;
-            }
-        } as ReactiveState;
-
-        objectGraph.set(distortedValue, reactiveState);
-        return reactiveState;
+        return proxy
     }
-
 }

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -119,6 +119,6 @@ export class ReactiveMembrane {
             registerProxy(proxy, value);
             objectGraph.set(distortedValue, proxy);
         }
-        return proxy
+        return proxy;
     }
 }

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -108,7 +108,7 @@ export class ReactiveMembrane {
     }
 
     private getReactiveHandler(value: any, distortedValue: any, readOnly: boolean): any {
-        const objectGraph = readOnly ? this.readOnlyObjectGraph : this.reactiveObjectGraph
+        const objectGraph = readOnly ? this.readOnlyObjectGraph : this.reactiveObjectGraph;
         let proxy = objectGraph.get(distortedValue);
         if (isUndefined(proxy)) {
             // caching the proxy after the first time it is accessed

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -1028,4 +1028,9 @@ describe('ReactiveHandler', () => {
             expect((dry as any).$$MagicKey$$).toBe('bar');
         });
     });
+    it('should return undefined when input is undefined', () => {
+        const target = new ReactiveMembrane();
+        const state = target.getProxy(undefined);
+        expect(state).toBe(undefined);
+    });
 });

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -435,4 +435,9 @@ describe('ReadOnlyHandler', () => {
             `"Invalid mutation: Cannot mutate array at index 0. Array is read-only."`
         );
     });
+    it('should return undefined when input is undefined', () => {
+        const target = new ReactiveMembrane();
+        const state = target.getReadOnlyProxy(undefined);
+        expect(state).toBe(undefined);
+    });
 });


### PR DESCRIPTION
This is a performance optimization for two reasons:

1. We avoid creating an extra object (`{ readOnly: ..., reactive: ... }`). Instead, we just keep track of the `readOnly` and `reactive` functions separately.
2. We avoid calling `Object.defineProperty` when the getter is called (since we don't have an object, it's no longer needed).

In the [perf benchmarks](https://docs.google.com/spreadsheets/d/1wkkHeq2hDnzzYXN9XnSFSwnk3ja_FCb-rP9b9e5ozyY/edit?usp=sharing), this is a 1-7% improvement and no regression:

![Screen Shot 2021-10-29 at 10 20 03 AM](https://user-images.githubusercontent.com/283842/139476720-5863fbdc-ed9c-447d-81f2-b49292dcf793.png)

This benchmark uses this PR on top of v1.0.1 (to avoid including changes in v1.1.3), with Tachometer set to 1% horizon, 20 min timeout, and 100 min samples, on a MacBook Pro running Chrome 95.