### PR TITLE
test: increase test coverage to 100%

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,13 @@ module.exports = {
         "ts-jest": {
             diagnostics: false
         }
+    },
+    coverageThreshold: {
+        global: {
+            branches: 100,
+            functions: 100,
+            lines: 100,
+            statements: 100
+        }
     }
 };

--- a/src/base-handler.ts
+++ b/src/base-handler.ts
@@ -53,6 +53,8 @@ export abstract class BaseProxyHandler {
         //       but it will always be compatible with the previous descriptor
         //       to preserve the object invariants, which makes these lines safe.
         const originalDescriptor = getOwnPropertyDescriptor(originalTarget, key);
+        // TODO: it should be impossible for the originalDescriptor to ever be undefined, this `if` can be removed
+        /* istanbul ignore else */
         if (!isUndefined(originalDescriptor)) {
             const wrappedDesc = this.wrapDescriptor(originalDescriptor);
             ObjectDefineProperty(shadowTarget, key, wrappedDesc);
@@ -81,9 +83,13 @@ export abstract class BaseProxyHandler {
 
     // Shared Traps
 
+    // TODO: apply() is never called
+    /* istanbul ignore next */
     apply(shadowTarget: ReactiveMembraneShadowTarget, thisArg: any, argArray: any[]) {
         /* No op */
     }
+    // TODO: construct() is never called
+    /* istanbul ignore next */
     construct(shadowTarget: ReactiveMembraneShadowTarget, argArray: any, newTarget?: any): any {
         /* No op */
     }

--- a/src/reactive-dev-formatter.ts
+++ b/src/reactive-dev-formatter.ts
@@ -66,6 +66,7 @@ const formatter: DevToolFormatter = {
 
 // Inspired from paulmillr/es6-shim
 // https://github.com/paulmillr/es6-shim/blob/master/es6-shim.js#L176-L185
+/* istanbul ignore next */
 function getGlobal(): any {
     // the only reliable means to get the global object is `Function('return this')()`
     // However, this causes CSP violations in Chrome apps.
@@ -79,6 +80,7 @@ function getGlobal(): any {
 }
 
 export function init() {
+    /* istanbul ignore if */
     if (process.env.NODE_ENV === 'production') {
         // this method should never leak to prod
         throw new ReferenceError();

--- a/src/reactive-handler.ts
+++ b/src/reactive-handler.ts
@@ -112,6 +112,7 @@ export class ReactiveProxyHandler extends BaseProxyHandler {
         return true;
     }
     setPrototypeOf(shadowTarget: ReactiveMembraneShadowTarget, prototype: any): any {
+        /* istanbul ignore else */
         if (process.env.NODE_ENV !== 'production') {
             throw new Error(`Invalid setPrototypeOf invocation for reactive proxy ${toString(this.originalTarget)}. Prototype of reactive objects cannot be changed.`);
         }
@@ -123,6 +124,10 @@ export class ReactiveProxyHandler extends BaseProxyHandler {
             // if the originalTarget is a proxy itself, it might reject
             // the preventExtension call, in which case we should not attempt to lock down
             // the shadow target.
+            // TODO: It should not actually be possible to reach this `if` statement.
+            // If a proxy rejects extensions, then calling preventExtensions will throw an error:
+            // https://codepen.io/nolanlawson-the-selector/pen/QWMOjbY
+            /* istanbul ignore if */
             if (isExtensible(originalTarget)) {
                 return false;
             }

--- a/src/reactive-membrane.ts
+++ b/src/reactive-membrane.ts
@@ -11,6 +11,7 @@ import { ReactiveProxyHandler } from './reactive-handler';
 import { ReadOnlyHandler } from './read-only-handler';
 import { init as initDevFormatter } from './reactive-dev-formatter';
 
+/* istanbul ignore else */
 if (process.env.NODE_ENV !== 'production') {
     initDevFormatter();
 }

--- a/src/read-only-handler.ts
+++ b/src/read-only-handler.ts
@@ -28,6 +28,7 @@ export class ReadOnlyHandler extends BaseProxyHandler {
         }
         const handler = this;
         const set = function (this: any, v: any) {
+            /* istanbul ignore else */
             if (process.env.NODE_ENV !== 'production') {
                 const { originalTarget } = handler;
                 throw new Error(`Invalid mutation: Cannot invoke a setter on "${originalTarget}". "${originalTarget}" is read-only.`);
@@ -37,6 +38,7 @@ export class ReadOnlyHandler extends BaseProxyHandler {
         return set;
     }
     set(shadowTarget: ReactiveMembraneShadowTarget, key: ProxyPropertyKey, value: any): boolean {
+        /* istanbul ignore else */
         if (process.env.NODE_ENV !== 'production') {
             const { originalTarget } = this;
             const msg = isArray(originalTarget) ?
@@ -44,33 +46,41 @@ export class ReadOnlyHandler extends BaseProxyHandler {
                 `Invalid mutation: Cannot set "${key.toString()}" on "${originalTarget}". "${originalTarget}" is read-only.`;
             throw new Error(msg);
         }
+        /* istanbul ignore next */
         return false;
     }
     deleteProperty(shadowTarget: ReactiveMembraneShadowTarget, key: ProxyPropertyKey): boolean {
+        /* istanbul ignore else */
         if (process.env.NODE_ENV !== 'production') {
             const { originalTarget } = this;
             throw new Error(`Invalid mutation: Cannot delete "${key.toString()}" on "${originalTarget}". "${originalTarget}" is read-only.`);
         }
+        /* istanbul ignore next */
         return false;
     }
     setPrototypeOf(shadowTarget: ReactiveMembraneShadowTarget, prototype: any): any {
+        /* istanbul ignore else */
         if (process.env.NODE_ENV !== 'production') {
             const { originalTarget } = this;
             throw new Error(`Invalid prototype mutation: Cannot set prototype on "${originalTarget}". "${originalTarget}" prototype is read-only.`);
         }
     }
     preventExtensions(shadowTarget: ReactiveMembraneShadowTarget): boolean {
+        /* istanbul ignore else */
         if (process.env.NODE_ENV !== 'production') {
             const { originalTarget } = this;
             throw new Error(`Invalid mutation: Cannot preventExtensions on ${originalTarget}". "${originalTarget} is read-only.`);
         }
+        /* istanbul ignore next */
         return false;
     }
     defineProperty(shadowTarget: ReactiveMembraneShadowTarget, key: ProxyPropertyKey, descriptor: PropertyDescriptor): boolean {
+        /* istanbul ignore else */
         if (process.env.NODE_ENV !== 'production') {
             const { originalTarget } = this;
             throw new Error(`Invalid mutation: Cannot defineProperty "${key.toString()}" on "${originalTarget}". "${originalTarget}" is read-only.`);
         }
+        /* istanbul ignore next */
         return false;
     }
 }

--- a/test/reactive-dev-formatter.spec.ts
+++ b/test/reactive-dev-formatter.spec.ts
@@ -13,16 +13,41 @@ describe('reactive dev formatter', function() {
     it('should return correct object when given reactive proxy', function() {
         const el = document.createElement('div');
         const reactiveMembrane = new ReactiveMembrane();
-        const proxy = reactiveMembrane.getProxy({ foo: 'bar', el });
+        const proxy = reactiveMembrane.getProxy({ foo: 'bar', el, baz: { quux: 'quux' } });
         const result = (window as any).devtoolsFormatters[0].header(proxy);
         expect(result).toEqual([
             'object', {
                 object: {
                     foo: 'bar',
-                    el
+                    baz: { quux: 'quux' },
+                    el,
                 }
             }
         ]);
         expect(result[1].object.el).toBe(el);
+    });
+
+    it('should return correct array when given an array', () => {
+        const el = document.createElement('div');
+        const reactiveMembrane = new ReactiveMembrane();
+        const proxy = reactiveMembrane.getProxy([{ foo: 'bar', el }, undefined]);
+        const result = (window as any).devtoolsFormatters[0].header(proxy);
+        expect(result).toEqual([
+            'object', {
+                object: [
+                    {
+                        foo: 'bar',
+                        el
+                    },
+                    undefined
+                ]
+            }
+        ]);
+        expect(result[1].object[0].el).toBe(el);
+    });
+
+    it('body is always null', () => {
+        expect((window as any).devtoolsFormatters[0].hasBody({})).toBe(false);
+        expect((window as any).devtoolsFormatters[0].body({})).toBe(null);
     });
 });

--- a/test/reactive-dev-formatter.spec.ts
+++ b/test/reactive-dev-formatter.spec.ts
@@ -48,6 +48,6 @@ describe('reactive dev formatter', function() {
 
     it('body is always null', () => {
         expect((window as any).devtoolsFormatters[0].hasBody({})).toBe(false);
-        expect((window as any).devtoolsFormatters[0].body({})).toBe(null);
+        expect((window as any).devtoolsFormatters[0].body({})).toBeNull();
     });
 });

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -890,6 +890,7 @@ describe('ReactiveHandler', () => {
 
             expect(property.foo).toEqual([]);
 
+            // Explicitly set the length twice, to trigger the code path for unchanged values
             property.foo.length = 0;
 
             expect(property.foo).toEqual([]);
@@ -905,6 +906,7 @@ describe('ReactiveHandler', () => {
             expect([...property.foo]).toEqual(['bar', 'baz']);
             expect(property.foo.expando).toEqual(0);
 
+            // Explicitly set the expando twice, to trigger the code path for unchanged values
             property.foo.expando = 0;
 
             expect([...property.foo]).toEqual(['bar', 'baz']);

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -158,7 +158,7 @@ describe('ReactiveHandler', () => {
         const obj = {};
         const property = target.getProxy(obj);
         const desc = Object.getOwnPropertyDescriptor(property, 'fake');
-        expect(desc).toBe(undefined);
+        expect(desc).toBeUndefined();
     });
     it('should handle has correctly', function() {
         const target = new ReactiveMembrane();

--- a/test/reactive-handler.spec.ts
+++ b/test/reactive-handler.spec.ts
@@ -193,13 +193,7 @@ describe('ReactiveHandler', () => {
     });
     it('should handle extensible correctly when target is frozen', function() {
         const target = new ReactiveMembrane();
-        const hello = {
-            hello: 'world'
-        };
-
-        const obj = {
-            hello
-        };
+        const obj = {};
 
         const wrapped = target.getProxy(obj);
         Object.freeze(wrapped);
@@ -207,13 +201,7 @@ describe('ReactiveHandler', () => {
     });
     it('should handle extensible correctly when original target is frozen', function() {
         const target = new ReactiveMembrane();
-        const hello = {
-            hello: 'world'
-        };
-
-        const obj = Object.freeze({
-            hello
-        });
+        const obj = Object.freeze({});
 
         const wrapped = target.getProxy(obj);
         expect(Object.isExtensible(wrapped)).toBe(false);

--- a/test/read-only-handler.spec.ts
+++ b/test/read-only-handler.spec.ts
@@ -129,7 +129,17 @@ describe('ReadOnlyHandler', () => {
             });
         }).toThrow();
     });
+    it('setPrototypeOf should throw', function() {
+        const target = new ReactiveMembrane();
+        const obj = {
+            foo: 'bar'
+        };
+        const property = target.getReadOnlyProxy(obj);
 
+        expect(() => {
+            Object.setPrototypeOf(property, {});
+        }).toThrow();
+    });
     it('should handle Object.getOwnPropertyNames correctly', function() {
         const target = new ReactiveMembrane();
         const obj = {

--- a/test/shared.spec.ts
+++ b/test/shared.spec.ts
@@ -1,4 +1,5 @@
 import { ReactiveMembrane } from '../src/reactive-membrane';
+import { toString } from '../src/shared';
 
 describe('#defaultValueObservable', function() {
     const isObservable = new ReactiveMembrane().valueIsObservable;
@@ -65,5 +66,15 @@ describe('#defaultValueObservable', function() {
         document.body.appendChild(iframe);
         const obj = (iframe.contentWindow as any).eval('({})');
         expect(isObservable(obj)).toBe(true);
+    });
+
+    it('toString() works objects without toString()', () => {
+        const obj = Object.create(null);
+        obj.foo = 'bar';
+        expect(toString(obj)).toEqual(toString({ foo: 'bar' }))
+    });
+
+    it('toString() works for undefined', () => {
+        expect(toString(undefined)).toEqual(undefined + '');
     });
 });


### PR DESCRIPTION
It makes me nervous when the tests don't cover everything 100%.

- Sets `jest.config.js` to require a `coverageThreshold` of 100%
- Adds new tests to test existing behavior
- Adds `/* istanbul ignore */` comments where necessary
- Does not change any existing code behavior