### PR TITLE
chore: fix circle ci publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - restore_yarn_cache
       - run:
-          name: Install dependencies and build
+          name: Install dependencies
           command: yarn install --frozen-lockfile
       - run:
           name: Run linter
@@ -69,7 +69,6 @@ jobs:
       - run:
           name: Run unit tests
           command: yarn test --runInBand
-      - save_workspace
 
   deploy:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - restore_yarn_cache
       - run:
-          name: Install dependencies
+          name: Install dependencies and build
           command: yarn install --frozen-lockfile
       - run:
           name: Run linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,11 +69,15 @@ jobs:
       - run:
           name: Run unit tests
           command: yarn test --runInBand
+      - save_workspace
 
   deploy:
     executor: node
     steps:
       - load_workspace
+      - run:
+          name: Check that publishable files exist
+          command: ls ./dist/commonjs/observable-membrane.js
       - run:
           name: Configure NPM authentication
           command: npm config set "//registry.npmjs.org/:_authToken" "$NPM_AUTOMATION_TOKEN"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "jest --config jest.config.js --coverage",
     "prebuild": "rm -rf dist",
     "build": "tsc --emitDeclarationOnly && rollup -c",
+    "prepare": "yarn build",
     "changelog": "yarn changelog:generate && yarn changelog:publish",
     "changelog:generate": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "changelog:publish": "git add CHANGELOG.md && git commit -m 'docs(changelog): publish release changelog' && git push",


### PR DESCRIPTION
I'm not sure why [1.1.4 was a botched release](https://unpkg.com/browse/observable-membrane@1.1.4/), but it looks like the `dist/` files weren't copied from the test job to the deploy job. This adds an extra `save_workspace` which I'm hoping will fix it?

If not, I added a check that will fail if there isn't a `dist/` JS file to publish. In that case, we can just publish manually.