### PR TITLE
feat: Expose native ES module only (BREAKING CHANGE)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
       - load_workspace
       - run:
           name: Check that publishable files exist
-          command: ls ./dist/commonjs/observable-membrane.js
+          command: ls ./dist/observable-membrane.js
       - run:
           name: Configure NPM authentication
           command: npm config set "//registry.npmjs.org/:_authToken" "$NPM_AUTOMATION_TOKEN"

--- a/examples/reactivo-element/index.html
+++ b/examples/reactivo-element/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Reactivo Element Examples for ObservableMembrane</title>
         <script type="module">
-            import ObservableMembrane from "../../dist/observable-membrane.browser.js";
+            import ObservableMembrane from "../../dist/observable-membrane.prod.js";
 
             // ReactivoElement is a simple abstraction on top of Web Component
             class ReactiveElement extends HTMLElement {

--- a/examples/reactivo-element/index.html
+++ b/examples/reactivo-element/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Reactivo Element Examples for ObservableMembrane</title>
         <script type="module">
-            import { ObservableMembrane } from "../../dist/observable-membrane.browser.js";
+            import ObservableMembrane from "../../dist/observable-membrane.browser.js";
 
             // ReactivoElement is a simple abstraction on top of Web Component
             class ReactiveElement extends HTMLElement {

--- a/examples/reactivo-element/index.html
+++ b/examples/reactivo-element/index.html
@@ -2,9 +2,9 @@
 <html lang="en-US">
     <head>
         <title>Reactivo Element Examples for ObservableMembrane</title>
-        <script src="../../dist/umd/observable-membrane.js"></script>
+        <script type="module">
+            import { ObservableMembrane } from "../../dist/observable-membrane.browser.js";
 
-        <script>
             // ReactivoElement is a simple abstraction on top of Web Component
             class ReactiveElement extends HTMLElement {
                 constructor() {
@@ -44,9 +44,7 @@
                     });
                 }
             }
-        </script>
 
-        <script>
             class XFoo extends ReactiveElement {
                 constructor() {
                     super();

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     testEnvironment: "jsdom",
     preset: "ts-jest",
     globals: {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "observable-membrane",
   "version": "1.1.5",
   "description": "A Javascript Membrane implementation using Proxies to observe mutation on an object graph",
-  "main": "dist/observable-membrane.cjs",
+  "type": "module",
   "module": "dist/observable-membrane.js",
-  "typings": "dist/types/main.d.ts",
+  "typings": "dist/main.d.ts",
   "license": "MIT",
   "author": "David Turissini <dturissini@salesforce.com>",
   "keywords": [
@@ -63,10 +63,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./dist/observable-membrane.js"
-      },
-      "default": "./dist/observable-membrane.browser.js"
+      "browser": "./dist/observable-membrane.browser.js",
+      "default": "./dist/observable-membrane.js"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,10 +61,8 @@
     "{src,test,scripts}/**/*.{ts,js}": "prettier --write"
   },
   "exports": {
-    ".": {
-      "production": "./dist/observable-membrane.prod.js",
-      "default": "./dist/observable-membrane.js"
-    }
+    "production": "./dist/observable-membrane.prod.js",
+    "import": "./dist/observable-membrane.js"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "observable-membrane",
   "version": "1.1.5",
   "description": "A Javascript Membrane implementation using Proxies to observe mutation on an object graph",
-  "main": "dist/commonjs/observable-membrane.js",
-  "module": "dist/modules/observable-membrane.js",
+  "main": "dist/observable-membrane.cjs",
+  "module": "dist/observable-membrane.js",
   "typings": "dist/types/main.d.ts",
   "license": "MIT",
   "author": "David Turissini <dturissini@salesforce.com>",
@@ -31,7 +31,7 @@
     "lint": "tslint -p tsconfig.json",
     "test": "jest --config jest.config.js --coverage",
     "prebuild": "rm -rf dist",
-    "build": "tsc --emitDeclarationOnly && rollup -c",
+    "build": "rollup -c",
     "prepare": "yarn build",
     "release:publish:ci": "./scripts/release/publish.js",
     "release:version": "./scripts/release/version.js"
@@ -60,5 +60,13 @@
   "lint-staged": {
     "**/*.{ts,js}": "eslint",
     "{src,test,scripts}/**/*.{ts,js}": "prettier --write"
+  },
+  "exports": {
+    ".": {
+      "node": {
+        "import": "./dist/observable-membrane.js"
+      },
+      "default": "./dist/observable-membrane.browser.js"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "lint-staged": "^11.2.6",
     "prettier": "^2.4.1",
     "rollup": "^2.56.3",
-    "rollup-plugin-terser": "^7.0.2",
     "semver": "^7.3.5",
     "ts-jest": "^27.0.5",
     "tslib": "^2.3.1",
@@ -63,8 +62,11 @@
   },
   "exports": {
     ".": {
-      "browser": "./dist/observable-membrane.browser.js",
+      "production": "./dist/observable-membrane.prod.js",
       "default": "./dist/observable-membrane.js"
     }
+  },
+  "engines": {
+    "node": ">=12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "import": "./dist/observable-membrane.js"
   },
   "engines": {
-    "node": ">=12"
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { createRequire } from "node:module";
+import { createRequire } from "module";
 
 import replace from "@rollup/plugin-replace";
 import typescript from "@rollup/plugin-typescript";
@@ -16,28 +16,23 @@ export default [
     {
         input: "src/main.ts",
 
-        output: [
-            {
-                ...output,
-                format: "es",
-                file: "dist/observable-membrane.js",
-            },
-            {
-                ...output,
-                format: "cjs",
-                file: "dist/observable-membrane.cjs",
-            },
-        ],
+        output: {
+            ...output,
+            format: "es",
+            file: "dist/observable-membrane.js",
+        },
 
-        plugins: [typescript({
-            tsconfig: './tsconfig.json'
-        })],
+        plugins: [
+            typescript({
+                tsconfig: "./tsconfig.json",
+            }),
+        ],
     },
     {
         input: "src/main.ts",
 
         output: {
-            ...footer,
+            ...output,
             format: "es",
             file: "dist/observable-membrane.browser.js",
         },
@@ -48,7 +43,7 @@ export default [
                 preventAssignment: true,
             }),
             typescript({
-                tsconfig: './tsconfig.json'
+                tsconfig: "./tsconfig.json",
             }),
         ],
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,49 +1,47 @@
-"use strict";
+import { createRequire } from 'module';
 
-import { createRequire } from "module";
-
-import replace from "@rollup/plugin-replace";
-import typescript from "@rollup/plugin-typescript";
+import replace from '@rollup/plugin-replace';
+import typescript from '@rollup/plugin-typescript';
 
 const require = createRequire(import.meta.url);
-const { version } = require("./package.json");
+const { version } = require('./package.json');
 
-const banner = `/**\n * Copyright (C) 2017 salesforce.com, inc.\n */`;
-const footer = `/** version: ${version} */`;
-const output = { banner, footer };
+const output = { 
+    format: 'es', 
+    banner: `/**\n * Copyright (C) 2017 salesforce.com, inc.\n */`, 
+    footer: `/** version: ${version} */`
+};
 
 export default [
     {
-        input: "src/main.ts",
+        input: 'src/main.ts',
 
         output: {
             ...output,
-            format: "es",
-            file: "dist/observable-membrane.js",
+            file: 'dist/observable-membrane.js',
         },
 
         plugins: [
             typescript({
-                tsconfig: "./tsconfig.json",
+                tsconfig: './tsconfig.json',
             }),
         ],
     },
     {
-        input: "src/main.ts",
+        input: 'src/main.ts',
 
         output: {
             ...output,
-            format: "es",
-            file: "dist/observable-membrane.prod.js",
+            file: 'dist/observable-membrane.prod.js',
         },
 
         plugins: [
             replace({
-                "process.env.NODE_ENV": JSON.stringify("production"),
+                'process.env.NODE_ENV': JSON.stringify('production'),
                 preventAssignment: true,
             }),
             typescript({
-                tsconfig: "./tsconfig.json",
+                tsconfig: './tsconfig.json',
             }),
         ],
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,7 @@ export default [
         output: {
             ...output,
             format: "es",
-            file: "dist/observable-membrane.browser.js",
+            file: "dist/observable-membrane.prod.js",
         },
 
         plugins: [

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const execa = require('execa');
-const isCI = require('is-ci');
+import execa from 'execa';
+import isCI from 'is-ci';
 
 if (!isCI) {
     console.error('This script is only meant to run in CI.');

--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -6,15 +6,15 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const execa = require('execa');
-const semver = require('semver');
+import path from 'path';
+import { createRequire } from 'module';
 
-const path = require('path');
-const readline = require('readline');
+import execa from 'execa';
+import semver from 'semver';
+import readline from 'readline';
 
-const cwd = process.cwd();
-const packageJson = path.join(cwd, 'package.json');
-const currentVersion = require(packageJson).version;
+const require = createRequire(import.meta.url);
+const currentVersion = require('../../package.json').version;
 
 const VALID_SEMVER_KEYWORDS = [
     'major',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,12 @@
     // Compilation Configuration
     "target": "es2016",
     "declaration": true,
-    "module": "es2015",
-    "declarationDir": "dist/types",
+    "module": "ESNext",
+    "outDir": "dist",
+    "declarationDir": ".",
 
     // Environment Configuration
     "esModuleInterop": true,
-    "moduleResolution": "node",
-    "lib": ["es2015", "es2016", "dom"],
 
     // Enhance Strictness
     "strict": true,
@@ -17,10 +16,5 @@
     "suppressImplicitAnyIndexErrors": true,
     "noImplicitReturns": true,
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "test"
-  ]
+  "exclude": ["dist", "test"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
   integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
@@ -1189,7 +1189,7 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@^2.20.0:
+commander@^2.12.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2273,15 +2273,6 @@ jest-watcher@^27.3.1:
     jest-util "^27.3.1"
     string-length "^4.0.1"
 
-jest-worker@^26.2.1:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
-  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
-  dependencies:
-    "@types/node" "*"
-    merge-stream "^2.0.0"
-    supports-color "^7.0.0"
-
 jest-worker@^27.3.1:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.3.1.tgz#0def7feae5b8042be38479799aeb7b5facac24b2"
@@ -2855,13 +2846,6 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
-
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -2960,16 +2944,6 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-terser@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
-  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    jest-worker "^26.2.1"
-    serialize-javascript "^4.0.0"
-    terser "^5.0.0"
-
 rollup@^2.56.3:
   version "2.59.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.59.0.tgz#108c61b0fa0a37ebc8d1f164f281622056f0db59"
@@ -2984,15 +2958,15 @@ rxjs@^7.4.0:
   dependencies:
     tslib "~2.1.0"
 
-safe-buffer@^5.1.0, safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
@@ -3027,13 +3001,6 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
-  dependencies:
-    randombytes "^2.1.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -3080,7 +3047,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.20:
+source-map-support@^0.5.17, source-map-support@^0.5.6:
   version "0.5.20"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
   integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
@@ -3098,7 +3065,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3, source-map@~0.7.2:
+source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -3256,15 +3223,6 @@ terminal-link@^2.0.0:
   dependencies:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
-
-terser@^5.0.0:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.9.0.tgz#47d6e629a522963240f2b55fcaa3c99083d2c351"
-  integrity sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.7.2"
-    source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This PR removes the CommonJS output from this package. The ESM output is now exposed using the [`exports`](https://nodejs.org/api/packages.html#exports) field on the `package.json`. This package exposes 2 different ESM artifacts:
- `dist/observable-membrane.js`: For use with NodeJs or with bundlers like Rollup or Webpack. Leaves prod/dev branches with `process.env.NODE_ENV` guards (must be replaced by bundler). Exposed via the `import` condition.
- `dist/observable-membrane.prod.js`: Same as the previous artifact with all the dev only guards are stripped out. This artifact can safely be loaded in a browser directly. Exposed via the `production` condition.

Fixes #35. 

Misc changes:
- Make module resolution default to ESM via the `type` property in the `package.json`.
- Make rollup produce type definition instead of doing this in a pre-build step.
